### PR TITLE
feat: unit conversion, cost, and margin engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postinstall": "git config core.hooksPath .githooks",
     "build": "bun run --filter '*' build",
     "test": "bun run test:unit && bun run test:api && bun run test:component && bun run test:e2e",
-    "test:unit": "bun --bun vitest run tests/unit apps/*/tests/unit",
+    "test:unit": "bun --bun vitest run tests/unit apps/*/tests/unit packages/core",
     "test:api": "for f in apps/server/tests/integration/*.test.ts; do bun --bun vitest run \"$f\" || exit 1; done",
     "test:pg-container": "bun --bun vitest run apps/server/tests/integration/pg-container.test.ts",
     "test:component": "bun --bun vitest run --config apps/web/vitest.browser.config.ts",

--- a/packages/core/conversions.test.ts
+++ b/packages/core/conversions.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from 'vitest';
+import {
+  convertUnits,
+  calculateCost,
+  calculateMargin,
+  evaluateMargin,
+  computeOrderFields,
+} from './conversions';
+import type { Product } from './types';
+
+// Standard test product: 4x4 Welded Wire Mesh 10ga, 48"x120", cost $32/each
+const makeProduct = (overrides: Partial<Product['properties']> = {}): Product => ({
+  id: 'prod-1',
+  created_at: '2024-01-01T00:00:00Z',
+  properties: {
+    name: '4x4 Welded Wire Mesh - 10ga',
+    sku: 'WM-4x4-10GA',
+    material: 'Galvanized Steel',
+    width_inches: 48,
+    length_inches: 120,
+    weight_per_sqft: 0.58,
+    cost_per_each: 32.0,
+    cost_per_linft: 3.2,
+    cost_per_sqft: 0.8,
+    primary_cost_basis: 'each',
+    margin_target: 25,
+    margin_floor: 15,
+    ...overrides,
+  },
+});
+
+// ─── convertUnits ─────────────────────────────────────────────────────────────
+
+describe('convertUnits', () => {
+  it('converts 10 eaches to linft and sqft for 48"x120" product', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 10, 'each');
+
+    // 10 * (120/12) = 100 linft; 10 * (48*120)/144 = 400 sqft
+    expect(result.eaches).toBe(10);
+    expect(result.linear_feet).toBe(100);
+    expect(result.square_feet).toBe(400);
+  });
+
+  it('converts 100 linft to eaches and sqft (round-trip consistency)', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 100, 'linear_foot');
+
+    // 100 / (120/12) = 100 / 10 = 10 eaches; 10 * (48*120)/144 = 400 sqft
+    expect(result.eaches).toBe(10);
+    expect(result.linear_feet).toBe(100);
+    expect(result.square_feet).toBe(400);
+  });
+
+  it('converts 50 sqft to eaches and linft', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 50, 'square_foot');
+
+    // sqftPerEach = (48*120)/144 = 40
+    // eaches = 50 / 40 = 1.25
+    // linft = 1.25 * 10 = 12.5
+    expect(result.eaches).toBeCloseTo(1.25, 10);
+    expect(result.linear_feet).toBeCloseTo(12.5, 10);
+    expect(result.square_feet).toBeCloseTo(50, 10);
+  });
+
+  it('converts 400 sqft back to 10 eaches and 100 linft (full round-trip from eaches)', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 400, 'square_foot');
+
+    expect(result.eaches).toBeCloseTo(10, 10);
+    expect(result.linear_feet).toBeCloseTo(100, 10);
+    expect(result.square_feet).toBeCloseTo(400, 10);
+  });
+
+  it('handles fractional linear foot quantities (Scenario 3: 73 linft)', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 73, 'linear_foot');
+
+    // 73 / 10 = 7.3 eaches; 7.3 * 40 = 292 sqft
+    expect(result.eaches).toBeCloseTo(7.3, 10);
+    expect(result.linear_feet).toBeCloseTo(73, 10);
+    expect(result.square_feet).toBeCloseTo(292, 10);
+  });
+
+  it('handles 1 each correctly', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 1, 'each');
+
+    // length_inches=120 → linft = 10; sqft = (48*120)/144 = 40
+    expect(result.eaches).toBe(1);
+    expect(result.linear_feet).toBe(10);
+    expect(result.square_feet).toBe(40);
+  });
+
+  it('handles zero quantity', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 0, 'each');
+
+    expect(result.eaches).toBe(0);
+    expect(result.linear_feet).toBe(0);
+    expect(result.square_feet).toBe(0);
+  });
+
+  it('converts from linear_foot using Scenario 2 values (50 linft)', () => {
+    const product = makeProduct();
+    const result = convertUnits(product, 50, 'linear_foot');
+
+    // 50 / 10 = 5 eaches; 5 * 40 = 200 sqft
+    expect(result.eaches).toBe(5);
+    expect(result.linear_feet).toBe(50);
+    expect(result.square_feet).toBe(200);
+  });
+});
+
+// ─── calculateCost ────────────────────────────────────────────────────────────
+
+describe('calculateCost', () => {
+  it('uses cost_per_each when primary_cost_basis is each', () => {
+    const product = makeProduct({ primary_cost_basis: 'each' });
+    const conversions = { eaches: 10, linear_feet: 100, square_feet: 400 };
+
+    // 10 * 32 = 320
+    expect(calculateCost(product, conversions)).toBe(320);
+  });
+
+  it('uses cost_per_linft when primary_cost_basis is linear_foot', () => {
+    const product = makeProduct({ primary_cost_basis: 'linear_foot' });
+    const conversions = { eaches: 10, linear_feet: 100, square_feet: 400 };
+
+    // 100 * 3.20 = 320
+    expect(calculateCost(product, conversions)).toBeCloseTo(320, 10);
+  });
+
+  it('uses cost_per_sqft when primary_cost_basis is square_foot', () => {
+    const product = makeProduct({ primary_cost_basis: 'square_foot' });
+    const conversions = { eaches: 10, linear_feet: 100, square_feet: 400 };
+
+    // 400 * 0.80 = 320
+    expect(calculateCost(product, conversions)).toBeCloseTo(320, 10);
+  });
+
+  it('produces the same total cost regardless of which basis is used (consistent rates)', () => {
+    const conversions = { eaches: 10, linear_feet: 100, square_feet: 400 };
+
+    const costByEach = calculateCost(makeProduct({ primary_cost_basis: 'each' }), conversions);
+    const costByLinft = calculateCost(makeProduct({ primary_cost_basis: 'linear_foot' }), conversions);
+    const costBySqft = calculateCost(makeProduct({ primary_cost_basis: 'square_foot' }), conversions);
+
+    expect(costByEach).toBeCloseTo(costByLinft, 8);
+    expect(costByEach).toBeCloseTo(costBySqft, 8);
+  });
+
+  it('handles null cost for non-primary basis without error', () => {
+    const product = makeProduct({
+      primary_cost_basis: 'each',
+      cost_per_linft: null,
+      cost_per_sqft: null,
+    });
+    const conversions = { eaches: 5, linear_feet: 50, square_feet: 200 };
+
+    expect(calculateCost(product, conversions)).toBe(160); // 5 * 32
+  });
+});
+
+// ─── calculateMargin ──────────────────────────────────────────────────────────
+
+describe('calculateMargin', () => {
+  it('calculates positive margin (Scenario 1)', () => {
+    const result = calculateMargin(450, 320);
+
+    expect(result.dollars).toBeCloseTo(130, 10);
+    // 130/450 * 100 ≈ 28.888...
+    expect(result.percent).toBeCloseTo((130 / 450) * 100, 10);
+  });
+
+  it('calculates zero margin (revenue equals cost)', () => {
+    const result = calculateMargin(100, 100);
+
+    expect(result.dollars).toBe(0);
+    expect(result.percent).toBe(0);
+  });
+
+  it('calculates negative margin (loss)', () => {
+    const result = calculateMargin(100, 150);
+
+    expect(result.dollars).toBe(-50);
+    expect(result.percent).toBeCloseTo(-50, 10);
+  });
+
+  it('handles zero revenue without error (returns 0% margin)', () => {
+    const result = calculateMargin(0, 0);
+
+    expect(result.dollars).toBe(0);
+    expect(result.percent).toBe(0);
+  });
+
+  it('handles zero revenue with non-zero cost (no division by zero)', () => {
+    const result = calculateMargin(0, 50);
+
+    expect(result.dollars).toBe(-50);
+    expect(result.percent).toBe(0); // defined as 0 when revenue=0
+  });
+
+  it('matches Scenario 2 economics (50 linft at $5/linft, 5 eaches @ $32)', () => {
+    const result = calculateMargin(250, 160);
+
+    expect(result.dollars).toBeCloseTo(90, 10);
+    expect(result.percent).toBeCloseTo(36, 10);
+  });
+});
+
+// ─── evaluateMargin ───────────────────────────────────────────────────────────
+
+describe('evaluateMargin', () => {
+  const target = 25;
+  const floor = 15;
+
+  it('returns healthy when margin is at or above target', () => {
+    expect(evaluateMargin(25, target, floor)).toBe('healthy');
+    expect(evaluateMargin(28.9, target, floor)).toBe('healthy');
+    expect(evaluateMargin(100, target, floor)).toBe('healthy');
+  });
+
+  it('returns warning when margin is between floor and target', () => {
+    expect(evaluateMargin(15, target, floor)).toBe('warning');
+    expect(evaluateMargin(20, target, floor)).toBe('warning');
+    expect(evaluateMargin(24.9, target, floor)).toBe('warning');
+  });
+
+  it('returns critical when margin is below floor', () => {
+    expect(evaluateMargin(14.9, target, floor)).toBe('critical');
+    expect(evaluateMargin(0, target, floor)).toBe('critical');
+    expect(evaluateMargin(-10, target, floor)).toBe('critical');
+  });
+
+  it('uses per-product thresholds (Scenario 4: target=18, floor=10)', () => {
+    // 13.7% is between 10% floor and 18% target → warning
+    expect(evaluateMargin(13.7, 18, 10)).toBe('warning');
+    expect(evaluateMargin(18, 18, 10)).toBe('healthy');
+    expect(evaluateMargin(9.9, 18, 10)).toBe('critical');
+  });
+});
+
+// ─── computeOrderFields ───────────────────────────────────────────────────────
+
+describe('computeOrderFields', () => {
+  it('computes all fields for Scenario 1 (10 eaches at $45 each)', () => {
+    const product = makeProduct();
+    const result = computeOrderFields(product, 10, 'each', 45);
+
+    expect(result.qty_eaches).toBe(10);
+    expect(result.qty_linft).toBe(100);
+    expect(result.qty_sqft).toBe(400);
+    expect(result.total_revenue).toBe(450);
+    expect(result.total_cost).toBe(320);
+    expect(result.margin_dollars).toBeCloseTo(130, 10);
+    expect(result.margin_percent).toBeCloseTo((130 / 450) * 100, 6);
+  });
+
+  it('computes all fields for Scenario 2 (50 linft at $5/linft)', () => {
+    const product = makeProduct();
+    const result = computeOrderFields(product, 50, 'linear_foot', 5);
+
+    expect(result.qty_eaches).toBe(5);
+    expect(result.qty_linft).toBe(50);
+    expect(result.qty_sqft).toBe(200);
+    expect(result.total_revenue).toBe(250);
+    expect(result.total_cost).toBe(160); // 5 eaches * $32
+    expect(result.margin_dollars).toBeCloseTo(90, 10);
+    expect(result.margin_percent).toBeCloseTo(36, 10);
+  });
+
+  it('computes all fields for Scenario 3 (73 linft at $4.80, fractional eaches)', () => {
+    const product = makeProduct();
+    const result = computeOrderFields(product, 73, 'linear_foot', 4.8);
+
+    expect(result.qty_eaches).toBeCloseTo(7.3, 10);
+    expect(result.qty_linft).toBeCloseTo(73, 10);
+    expect(result.qty_sqft).toBeCloseTo(292, 10);
+    expect(result.total_revenue).toBeCloseTo(350.4, 10);
+    expect(result.total_cost).toBeCloseTo(7.3 * 32, 10);
+    expect(result.margin_dollars).toBeCloseTo(350.4 - 7.3 * 32, 10);
+  });
+
+  it('handles zero sell price (zero revenue, zero or negative margin)', () => {
+    const product = makeProduct();
+    const result = computeOrderFields(product, 10, 'each', 0);
+
+    expect(result.total_revenue).toBe(0);
+    expect(result.total_cost).toBe(320);
+    expect(result.margin_dollars).toBe(-320);
+    expect(result.margin_percent).toBe(0); // revenue=0, returns 0%
+  });
+
+  it('uses linear_foot basis cost calculation correctly', () => {
+    const product = makeProduct({ primary_cost_basis: 'linear_foot' });
+    const result = computeOrderFields(product, 10, 'each', 45);
+
+    // 100 linft * $3.20 = $320 — same as per-each for consistent rates
+    expect(result.total_cost).toBeCloseTo(320, 6);
+  });
+
+  it('uses square_foot basis cost calculation correctly', () => {
+    const product = makeProduct({ primary_cost_basis: 'square_foot' });
+    const result = computeOrderFields(product, 10, 'each', 45);
+
+    // 400 sqft * $0.80 = $320 — same as per-each for consistent rates
+    expect(result.total_cost).toBeCloseTo(320, 6);
+  });
+});

--- a/packages/core/conversions.test.ts
+++ b/packages/core/conversions.test.ts
@@ -144,8 +144,14 @@ describe('calculateCost', () => {
     const conversions = { eaches: 10, linear_feet: 100, square_feet: 400 };
 
     const costByEach = calculateCost(makeProduct({ primary_cost_basis: 'each' }), conversions);
-    const costByLinft = calculateCost(makeProduct({ primary_cost_basis: 'linear_foot' }), conversions);
-    const costBySqft = calculateCost(makeProduct({ primary_cost_basis: 'square_foot' }), conversions);
+    const costByLinft = calculateCost(
+      makeProduct({ primary_cost_basis: 'linear_foot' }),
+      conversions,
+    );
+    const costBySqft = calculateCost(
+      makeProduct({ primary_cost_basis: 'square_foot' }),
+      conversions,
+    );
 
     expect(costByEach).toBeCloseTo(costByLinft, 8);
     expect(costByEach).toBeCloseTo(costBySqft, 8);

--- a/packages/core/conversions.ts
+++ b/packages/core/conversions.ts
@@ -1,9 +1,4 @@
-import type {
-  Product,
-  UnitOfMeasure,
-  UnitConversions,
-  MarginResult,
-} from './types';
+import type { Product, UnitOfMeasure, UnitConversions, MarginResult } from './types';
 
 /**
  * Convert a quantity in any unit to all three units (eaches, linear_feet, square_feet).
@@ -48,12 +43,8 @@ export function convertUnits(
  * Calculate total cost using the product's primary_cost_basis and the
  * corresponding converted quantity.
  */
-export function calculateCost(
-  product: Product,
-  conversions: UnitConversions,
-): number {
-  const { primary_cost_basis, cost_per_each, cost_per_linft, cost_per_sqft } =
-    product.properties;
+export function calculateCost(product: Product, conversions: UnitConversions): number {
+  const { primary_cost_basis, cost_per_each, cost_per_linft, cost_per_sqft } = product.properties;
 
   switch (primary_cost_basis) {
     case 'each':

--- a/packages/core/conversions.ts
+++ b/packages/core/conversions.ts
@@ -1,0 +1,132 @@
+import type {
+  Product,
+  UnitOfMeasure,
+  UnitConversions,
+  MarginResult,
+} from './types';
+
+/**
+ * Convert a quantity in any unit to all three units (eaches, linear_feet, square_feet).
+ *
+ * Formulas (PRD Section 5):
+ *   1 each = (length_inches / 12) linear feet
+ *   1 each = (width_inches * length_inches) / 144 square feet
+ */
+export function convertUnits(
+  product: Product,
+  quantity: number,
+  fromUnit: UnitOfMeasure,
+): UnitConversions {
+  const { width_inches, length_inches } = product.properties;
+
+  // Conversion factors relative to one each
+  const linftPerEach = length_inches / 12;
+  const sqftPerEach = (width_inches * length_inches) / 144;
+
+  let eaches: number;
+
+  switch (fromUnit) {
+    case 'each':
+      eaches = quantity;
+      break;
+    case 'linear_foot':
+      eaches = quantity / linftPerEach;
+      break;
+    case 'square_foot':
+      eaches = quantity / sqftPerEach;
+      break;
+  }
+
+  return {
+    eaches,
+    linear_feet: eaches * linftPerEach,
+    square_feet: eaches * sqftPerEach,
+  };
+}
+
+/**
+ * Calculate total cost using the product's primary_cost_basis and the
+ * corresponding converted quantity.
+ */
+export function calculateCost(
+  product: Product,
+  conversions: UnitConversions,
+): number {
+  const { primary_cost_basis, cost_per_each, cost_per_linft, cost_per_sqft } =
+    product.properties;
+
+  switch (primary_cost_basis) {
+    case 'each':
+      return (cost_per_each ?? 0) * conversions.eaches;
+    case 'linear_foot':
+      return (cost_per_linft ?? 0) * conversions.linear_feet;
+    case 'square_foot':
+      return (cost_per_sqft ?? 0) * conversions.square_feet;
+  }
+}
+
+/**
+ * Calculate margin dollars and percent from revenue and cost.
+ * Returns percent = 0 when revenue is 0 to avoid division by zero.
+ */
+export function calculateMargin(revenue: number, cost: number): MarginResult {
+  const dollars = revenue - cost;
+  const percent = revenue === 0 ? 0 : (dollars / revenue) * 100;
+  return { dollars, percent };
+}
+
+/**
+ * Evaluate margin health against product thresholds.
+ *
+ * healthy  : percent >= target
+ * warning  : floor <= percent < target
+ * critical : percent < floor
+ */
+export function evaluateMargin(
+  percent: number,
+  target: number,
+  floor: number,
+): 'healthy' | 'warning' | 'critical' {
+  if (percent >= target) return 'healthy';
+  if (percent >= floor) return 'warning';
+  return 'critical';
+}
+
+export interface ComputedOrderFields {
+  qty_eaches: number;
+  qty_linft: number;
+  qty_sqft: number;
+  total_revenue: number;
+  total_cost: number;
+  margin_dollars: number;
+  margin_percent: number;
+}
+
+/**
+ * Orchestrates conversion → cost → margin in a single call.
+ * Used by both the server (authoritative) and the client (live preview).
+ */
+export function computeOrderFields(
+  product: Product,
+  quantity: number,
+  unit: UnitOfMeasure,
+  sellPricePerUnit: number,
+): ComputedOrderFields {
+  const conversions = convertUnits(product, quantity, unit);
+  const total_revenue = quantity * sellPricePerUnit;
+  const total_cost = calculateCost(product, conversions);
+  const { dollars: margin_dollars, percent: margin_percent } = calculateMargin(
+    total_revenue,
+    total_cost,
+  );
+
+  return {
+    qty_eaches: conversions.eaches,
+    qty_linft: conversions.linear_feet,
+    qty_sqft: conversions.square_feet,
+    total_revenue,
+    total_cost,
+    margin_dollars,
+    margin_percent,
+  };
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './data-policies';
+export * from './conversions';
 export const coreHelper = () => true;


### PR DESCRIPTION
## Summary

Implements #3.

Adds pure conversion, cost, and margin functions to `packages/core/conversions.ts`:
- `convertUnits` — converts between eaches, linear feet, and square feet using product dimensions (PRD Section 5 math)
- `calculateCost` — selects cost rate based on `primary_cost_basis`
- `calculateMargin` — returns dollars and percent, handles zero revenue
- `evaluateMargin` — returns 'healthy' / 'warning' / 'critical' based on product thresholds
- `computeOrderFields` — orchestrates all steps in one call

Also adds 29 tests in `packages/core/conversions.test.ts` covering all test plan items including the PRD Scenario 1 end-to-end case.

## Test plan

- 40/40 tests pass (29 new conversion + 9 type + 2 app stubs)
- `bun run build`: zero type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)