### PR TITLE
feat: products API (CRUD endpoints)

### DIFF
--- a/apps/server/src/api/products.ts
+++ b/apps/server/src/api/products.ts
@@ -1,0 +1,221 @@
+import { sql } from 'db';
+import type { Product, ProductProperties, CostBasis } from 'core';
+import { getAuthenticatedUser, getCorsHeaders } from './auth';
+
+function validateProductProperties(
+  props: Partial<ProductProperties>,
+  isCreate: boolean,
+): string | null {
+  if (isCreate) {
+    if (!props.name) return 'Missing required field: name';
+    if (!props.sku) return 'Missing required field: sku';
+    if (props.width_inches === undefined || props.width_inches === null)
+      return 'Missing required field: width_inches';
+    if (props.length_inches === undefined || props.length_inches === null)
+      return 'Missing required field: length_inches';
+    if (!props.primary_cost_basis) return 'Missing required field: primary_cost_basis';
+  }
+
+  if (props.width_inches !== undefined && props.width_inches !== null && props.width_inches <= 0) {
+    return 'width_inches must be > 0';
+  }
+  if (
+    props.length_inches !== undefined &&
+    props.length_inches !== null &&
+    props.length_inches <= 0
+  ) {
+    return 'length_inches must be > 0';
+  }
+
+  const marginTarget = props.margin_target;
+  const marginFloor = props.margin_floor;
+  if (marginFloor !== undefined && marginFloor !== null && marginFloor < 0) {
+    return 'margin_floor must be >= 0';
+  }
+  if (
+    marginTarget !== undefined &&
+    marginTarget !== null &&
+    marginFloor !== undefined &&
+    marginFloor !== null
+  ) {
+    if (marginTarget <= marginFloor) {
+      return 'margin_target must be > margin_floor';
+    }
+  }
+
+  // Validate cost field matching primary_cost_basis
+  if (props.primary_cost_basis) {
+    const basis: CostBasis = props.primary_cost_basis;
+    if (basis === 'each' && (props.cost_per_each === null || props.cost_per_each === undefined)) {
+      return 'cost_per_each must be non-null when primary_cost_basis is each';
+    }
+    if (
+      basis === 'linear_foot' &&
+      (props.cost_per_linft === null || props.cost_per_linft === undefined)
+    ) {
+      return 'cost_per_linft must be non-null when primary_cost_basis is linear_foot';
+    }
+    if (
+      basis === 'square_foot' &&
+      (props.cost_per_sqft === null || props.cost_per_sqft === undefined)
+    ) {
+      return 'cost_per_sqft must be non-null when primary_cost_basis is square_foot';
+    }
+  }
+
+  return null;
+}
+
+function rowToProduct(row: {
+  id: string;
+  properties: ProductProperties;
+  created_at: string;
+}): Product {
+  return {
+    id: row.id,
+    created_at: row.created_at,
+    properties: row.properties,
+  };
+}
+
+export async function handleProductsRequest(req: Request, url: URL): Promise<Response | null> {
+  const corsHeaders = getCorsHeaders(req);
+
+  if (!url.pathname.startsWith('/api/products')) return null;
+
+  const user = await getAuthenticatedUser(req);
+  if (!user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  // GET /api/products
+  if (req.method === 'GET' && url.pathname === '/api/products') {
+    try {
+      const rows = await sql<{ id: string; properties: ProductProperties; created_at: string }[]>`
+        SELECT id, properties, created_at
+        FROM entities
+        WHERE type = 'product'
+        ORDER BY created_at DESC
+      `;
+      const products: Product[] = rows.map(rowToProduct);
+      return new Response(JSON.stringify(products), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('GET /api/products ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  // POST /api/products
+  if (req.method === 'POST' && url.pathname === '/api/products') {
+    try {
+      const body = await req.json();
+
+      const partial: Partial<ProductProperties> = {
+        name: body.name,
+        sku: body.sku,
+        material: body.material ?? '',
+        width_inches: body.width_inches,
+        length_inches: body.length_inches,
+        weight_per_sqft: body.weight_per_sqft ?? 0,
+        cost_per_each: body.cost_per_each ?? null,
+        cost_per_linft: body.cost_per_linft ?? null,
+        cost_per_sqft: body.cost_per_sqft ?? null,
+        primary_cost_basis: body.primary_cost_basis,
+        margin_target: body.margin_target ?? 25,
+        margin_floor: body.margin_floor ?? 15,
+      };
+
+      const validationError = validateProductProperties(partial, true);
+      if (validationError) {
+        return new Response(JSON.stringify({ error: validationError }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const properties: ProductProperties = partial as ProductProperties;
+      const id = crypto.randomUUID();
+
+      const rows = await sql<{ id: string; properties: ProductProperties; created_at: string }[]>`
+        INSERT INTO entities (id, type, properties, tenant_id)
+        VALUES (${id}, 'product', ${sql.json(properties)}, null)
+        RETURNING id, properties, created_at
+      `;
+
+      const product = rowToProduct(rows[0]);
+      return new Response(JSON.stringify(product), {
+        status: 201,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('POST /api/products ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  // PATCH /api/products/:id
+  const patchMatch = url.pathname.match(/^\/api\/products\/([^/]+)$/);
+  if (req.method === 'PATCH' && patchMatch) {
+    const productId = patchMatch[1];
+    try {
+      const existing = await sql<
+        { id: string; properties: ProductProperties; created_at: string }[]
+      >`
+        SELECT id, properties, created_at
+        FROM entities
+        WHERE id = ${productId} AND type = 'product'
+      `;
+
+      if (existing.length === 0) {
+        return new Response(JSON.stringify({ error: 'Product not found' }), {
+          status: 404,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const body = await req.json();
+      const merged: ProductProperties = { ...existing[0].properties, ...body };
+
+      const validationError = validateProductProperties(merged, false);
+      if (validationError) {
+        return new Response(JSON.stringify({ error: validationError }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const rows = await sql<{ id: string; properties: ProductProperties; created_at: string }[]>`
+        UPDATE entities
+        SET properties = ${sql.json(merged)}, updated_at = CURRENT_TIMESTAMP, version = version + 1
+        WHERE id = ${productId} AND type = 'product'
+        RETURNING id, properties, created_at
+      `;
+
+      const product = rowToProduct(rows[0]);
+      return new Response(JSON.stringify(product), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('PATCH /api/products/:id ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  return null;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,6 +7,7 @@
 
 import { migrate } from 'db';
 import { handleAuthRequest } from './api/auth';
+import { handleProductsRequest } from './api/products';
 
 await migrate();
 
@@ -30,6 +31,11 @@ export default {
     if (url.pathname.startsWith('/api/auth')) {
       const authRes = await handleAuthRequest(req, url);
       if (authRes) return authRes;
+    }
+
+    if (url.pathname.startsWith('/api/products')) {
+      const productsRes = await handleProductsRequest(req, url);
+      if (productsRes) return productsRes;
     }
 
     // Serve static assets — path is relative to this file, not process cwd

--- a/apps/server/tests/integration/products.test.ts
+++ b/apps/server/tests/integration/products.test.ts
@@ -1,0 +1,277 @@
+import { test, expect, beforeAll, afterAll } from 'vitest';
+import type { Subprocess } from 'bun';
+import { startPostgres, type PgContainer } from '../helpers/pg-container';
+
+const PORT = 31417;
+const BASE = `http://localhost:${PORT}`;
+const SERVER_READY_TIMEOUT_MS = 20_000;
+const REPO_ROOT = new URL('../../../../', import.meta.url).pathname;
+const SERVER_ENTRY = 'apps/server/src/index.ts';
+
+let pg: PgContainer;
+let server: Subprocess;
+let authCookie = '';
+
+beforeAll(async () => {
+  pg = await startPostgres();
+
+  server = Bun.spawn(['bun', 'run', SERVER_ENTRY], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, DATABASE_URL: pg.url, PORT: String(PORT) },
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+
+  await waitForServer(BASE);
+
+  // Register a test user and capture the session cookie
+  const username = `test_${Date.now()}`;
+  const res = await fetch(`${BASE}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password: 'testpass123' }),
+  });
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  authCookie = setCookie.split(';')[0];
+}, 60_000);
+
+afterAll(async () => {
+  server?.kill();
+  await pg?.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Products tests
+// ---------------------------------------------------------------------------
+
+const validProduct = {
+  name: '4x4 Welded Wire Mesh 10ga',
+  sku: 'WM-4x4-10GA',
+  material: 'Galvanized Steel',
+  width_inches: 48,
+  length_inches: 120,
+  weight_per_sqft: 0.58,
+  cost_per_each: 32.0,
+  cost_per_linft: null,
+  cost_per_sqft: null,
+  primary_cost_basis: 'each',
+};
+
+test('GET /api/products returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/products`);
+  expect(res.status).toBe(401);
+});
+
+test('POST /api/products returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(validProduct),
+  });
+  expect(res.status).toBe(401);
+});
+
+test('GET /api/products returns 200 with empty array initially', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    headers: { Cookie: authCookie },
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(Array.isArray(body)).toBe(true);
+});
+
+test('POST /api/products with valid data returns 201 with created product', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify(validProduct),
+  });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body.id).toBeTruthy();
+  expect(body.created_at).toBeTruthy();
+  expect(body.properties.name).toBe(validProduct.name);
+  expect(body.properties.sku).toBe(validProduct.sku);
+  expect(body.properties.primary_cost_basis).toBe('each');
+});
+
+test('POST /api/products applies default margin values when not provided', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: 'Test Product Defaults',
+      sku: 'TPD-001',
+      width_inches: 24,
+      length_inches: 60,
+      cost_per_each: 10.0,
+      primary_cost_basis: 'each',
+    }),
+  });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body.properties.margin_target).toBe(25);
+  expect(body.properties.margin_floor).toBe(15);
+  expect(body.properties.weight_per_sqft).toBe(0);
+});
+
+test('GET /api/products returns created product in the list', async () => {
+  // Create a product
+  const createRes = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: 'Listed Product',
+      sku: 'LP-001',
+      width_inches: 36,
+      length_inches: 72,
+      cost_per_each: 20.0,
+      primary_cost_basis: 'each',
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const created = await createRes.json();
+
+  // List products
+  const listRes = await fetch(`${BASE}/api/products`, {
+    headers: { Cookie: authCookie },
+  });
+  expect(listRes.status).toBe(200);
+  const products = await listRes.json();
+  const found = products.find((p: { id: string }) => p.id === created.id);
+  expect(found).toBeTruthy();
+});
+
+test('POST /api/products with missing name returns 400', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      sku: 'NONAME-001',
+      width_inches: 48,
+      length_inches: 120,
+      cost_per_each: 10,
+      primary_cost_basis: 'each',
+    }),
+  });
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toBeTruthy();
+});
+
+test('POST /api/products with missing sku returns 400', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: 'No SKU Product',
+      width_inches: 48,
+      length_inches: 120,
+      cost_per_each: 10,
+      primary_cost_basis: 'each',
+    }),
+  });
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toBeTruthy();
+});
+
+test('POST /api/products with cost_per_each=null when primary_cost_basis=each returns 400', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: 'Mismatched Cost',
+      sku: 'MC-001',
+      width_inches: 48,
+      length_inches: 120,
+      cost_per_each: null,
+      primary_cost_basis: 'each',
+    }),
+  });
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toContain('cost_per_each');
+});
+
+test('POST /api/products with zero width_inches returns 400', async () => {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: 'Zero Width',
+      sku: 'ZW-001',
+      width_inches: 0,
+      length_inches: 120,
+      cost_per_each: 10,
+      primary_cost_basis: 'each',
+    }),
+  });
+  expect(res.status).toBe(400);
+});
+
+test('PATCH /api/products/:id updates only supplied fields', async () => {
+  // Create product first
+  const createRes = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: 'Original Name',
+      sku: 'ORIG-001',
+      width_inches: 48,
+      length_inches: 120,
+      cost_per_each: 30.0,
+      primary_cost_basis: 'each',
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const created = await createRes.json();
+
+  // Patch only the name
+  const patchRes = await fetch(`${BASE}/api/products/${created.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ name: 'Updated Name' }),
+  });
+  expect(patchRes.status).toBe(200);
+  const updated = await patchRes.json();
+  expect(updated.properties.name).toBe('Updated Name');
+  // Other fields preserved
+  expect(updated.properties.sku).toBe('ORIG-001');
+  expect(updated.properties.cost_per_each).toBe(30.0);
+  expect(updated.properties.primary_cost_basis).toBe('each');
+});
+
+test('PATCH /api/products/:id returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/products/some-id`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Hacked' }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test('PATCH /api/products/:id returns 404 for nonexistent product', async () => {
+  const res = await fetch(`${BASE}/api/products/nonexistent-id`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ name: 'Ghost' }),
+  });
+  expect(res.status).toBe(404);
+});
+
+// ---------------------------------------------------------------------------
+
+/** Poll the server until it responds or we time out. */
+async function waitForServer(base: string): Promise<void> {
+  const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${base}/api/auth/me`);
+      return;
+    } catch {
+      await Bun.sleep(300);
+    }
+  }
+  throw new Error(`Server at ${base} did not become ready within ${SERVER_READY_TIMEOUT_MS}ms`);
+}


### PR DESCRIPTION
## Summary

Implements #4.

Adds Products API to `apps/server/src/api/products.ts`:
- `GET /api/products` — lists all products ordered by `created_at DESC`
- `POST /api/products` — creates product with validation (required fields, dimensions > 0, margin thresholds, cost basis matching); applies defaults: `margin_target=25`, `margin_floor=15`, `weight_per_sqft=0`; returns 201
- `PATCH /api/products/:id` — partial update with merge and re-validation; returns updated product

All endpoints require authentication. Router wired in `apps/server/src/index.ts`.

13 integration tests cover all acceptance criteria: happy paths, 401 unauthenticated, 400 validation errors (missing fields, mismatched cost basis, zero dimensions), 404 not found, partial update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)