### PR TITLE
feat: orders API (create, list, status transitions)

### DIFF
--- a/apps/server/src/api/orders.ts
+++ b/apps/server/src/api/orders.ts
@@ -1,0 +1,282 @@
+import { sql } from 'db';
+import type { Order, OrderProperties, ProductProperties } from 'core';
+import { computeOrderFields } from 'core';
+import { getAuthenticatedUser, getCorsHeaders } from './auth';
+
+function rowToOrder(row: { id: string; properties: OrderProperties; created_at: string }): Order {
+  return {
+    id: row.id,
+    created_at: row.created_at,
+    properties: row.properties,
+  };
+}
+
+export async function handleOrdersRequest(req: Request, url: URL): Promise<Response | null> {
+  const corsHeaders = getCorsHeaders(req);
+
+  if (!url.pathname.startsWith('/api/orders')) return null;
+
+  const user = await getAuthenticatedUser(req);
+  if (!user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  // GET /api/orders
+  if (req.method === 'GET' && url.pathname === '/api/orders') {
+    try {
+      const statusFilter = url.searchParams.get('status');
+      const customerFilter = url.searchParams.get('customer');
+
+      let rows: { id: string; properties: OrderProperties; created_at: string }[];
+
+      if (statusFilter && customerFilter) {
+        rows = await sql<{ id: string; properties: OrderProperties; created_at: string }[]>`
+          SELECT id, properties, created_at
+          FROM entities
+          WHERE type = 'order'
+            AND properties->>'status' = ${statusFilter}
+            AND LOWER(properties->>'customer') LIKE ${'%' + customerFilter.toLowerCase() + '%'}
+          ORDER BY created_at DESC
+        `;
+      } else if (statusFilter) {
+        rows = await sql<{ id: string; properties: OrderProperties; created_at: string }[]>`
+          SELECT id, properties, created_at
+          FROM entities
+          WHERE type = 'order'
+            AND properties->>'status' = ${statusFilter}
+          ORDER BY created_at DESC
+        `;
+      } else if (customerFilter) {
+        rows = await sql<{ id: string; properties: OrderProperties; created_at: string }[]>`
+          SELECT id, properties, created_at
+          FROM entities
+          WHERE type = 'order'
+            AND LOWER(properties->>'customer') LIKE ${'%' + customerFilter.toLowerCase() + '%'}
+          ORDER BY created_at DESC
+        `;
+      } else {
+        rows = await sql<{ id: string; properties: OrderProperties; created_at: string }[]>`
+          SELECT id, properties, created_at
+          FROM entities
+          WHERE type = 'order'
+          ORDER BY created_at DESC
+        `;
+      }
+
+      const orders: Order[] = rows.map(rowToOrder);
+      return new Response(JSON.stringify(orders), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('GET /api/orders ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  // POST /api/orders
+  if (req.method === 'POST' && url.pathname === '/api/orders') {
+    try {
+      const body = await req.json();
+
+      const { customer, product_id, quantity, unit_of_measure, sell_price_per_unit, notes } = body;
+
+      if (!customer) {
+        return new Response(JSON.stringify({ error: 'Missing required field: customer' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+      if (!product_id) {
+        return new Response(JSON.stringify({ error: 'Missing required field: product_id' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+      if (quantity === undefined || quantity === null) {
+        return new Response(JSON.stringify({ error: 'Missing required field: quantity' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+      if (!unit_of_measure) {
+        return new Response(JSON.stringify({ error: 'Missing required field: unit_of_measure' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+      if (sell_price_per_unit === undefined || sell_price_per_unit === null) {
+        return new Response(
+          JSON.stringify({ error: 'Missing required field: sell_price_per_unit' }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          },
+        );
+      }
+
+      // Fetch the product entity
+      const productRows = await sql<
+        { id: string; properties: ProductProperties; created_at: string }[]
+      >`
+        SELECT id, properties, created_at
+        FROM entities
+        WHERE id = ${product_id} AND type = 'product'
+      `;
+
+      if (productRows.length === 0) {
+        return new Response(JSON.stringify({ error: 'Product not found' }), {
+          status: 404,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const product = {
+        id: productRows[0].id,
+        created_at: productRows[0].created_at,
+        properties: productRows[0].properties,
+      };
+
+      // Compute all derived order fields
+      const computed = computeOrderFields(product, quantity, unit_of_measure, sell_price_per_unit);
+
+      const properties: OrderProperties = {
+        customer,
+        product_id,
+        product_name: product.properties.name,
+        quantity,
+        unit_of_measure,
+        sell_price_per_unit,
+        qty_eaches: computed.qty_eaches,
+        qty_linft: computed.qty_linft,
+        qty_sqft: computed.qty_sqft,
+        total_revenue: computed.total_revenue,
+        total_cost: computed.total_cost,
+        margin_dollars: computed.margin_dollars,
+        margin_percent: computed.margin_percent,
+        margin_target: product.properties.margin_target,
+        margin_floor: product.properties.margin_floor,
+        status: 'draft',
+        notes: notes ?? '',
+        created_by: user.id,
+        confirmed_by: null,
+        confirmed_at: null,
+        cancelled_by: null,
+        cancelled_at: null,
+      };
+
+      const id = crypto.randomUUID();
+
+      const rows = await sql<{ id: string; properties: OrderProperties; created_at: string }[]>`
+        INSERT INTO entities (id, type, properties, tenant_id)
+        VALUES (${id}, 'order', ${sql.json(properties)}, null)
+        RETURNING id, properties, created_at
+      `;
+
+      const order = rowToOrder(rows[0]);
+      return new Response(JSON.stringify(order), {
+        status: 201,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('POST /api/orders ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  // PATCH /api/orders/:id
+  const patchMatch = url.pathname.match(/^\/api\/orders\/([^/]+)$/);
+  if (req.method === 'PATCH' && patchMatch) {
+    const orderId = patchMatch[1];
+    try {
+      const existing = await sql<{ id: string; properties: OrderProperties; created_at: string }[]>`
+        SELECT id, properties, created_at
+        FROM entities
+        WHERE id = ${orderId} AND type = 'order'
+      `;
+
+      if (existing.length === 0) {
+        return new Response(JSON.stringify({ error: 'Order not found' }), {
+          status: 404,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const body = await req.json();
+      const currentProps = existing[0].properties;
+      const currentStatus = currentProps.status;
+      const newStatus = body.status;
+
+      // Validate status transition if status is being changed
+      if (newStatus !== undefined && newStatus !== currentStatus) {
+        const validTransitions: Record<string, string[]> = {
+          draft: ['confirmed', 'cancelled'],
+          confirmed: ['cancelled'],
+          cancelled: [],
+        };
+
+        const allowed = validTransitions[currentStatus] ?? [];
+        if (!allowed.includes(newStatus)) {
+          return new Response(
+            JSON.stringify({
+              error: `Invalid status transition: ${currentStatus} -> ${newStatus}`,
+            }),
+            {
+              status: 400,
+              headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            },
+          );
+        }
+      }
+
+      const updatedProps: OrderProperties = { ...currentProps };
+
+      if (body.notes !== undefined) {
+        updatedProps.notes = body.notes;
+      }
+
+      if (newStatus !== undefined && newStatus !== currentStatus) {
+        updatedProps.status = newStatus;
+        const now = new Date().toISOString();
+
+        if (newStatus === 'confirmed') {
+          updatedProps.confirmed_by = user.id;
+          updatedProps.confirmed_at = now;
+        } else if (newStatus === 'cancelled') {
+          updatedProps.cancelled_by = user.id;
+          updatedProps.cancelled_at = now;
+        }
+      }
+
+      const rows = await sql<{ id: string; properties: OrderProperties; created_at: string }[]>`
+        UPDATE entities
+        SET properties = ${sql.json(updatedProps)}, updated_at = CURRENT_TIMESTAMP, version = version + 1
+        WHERE id = ${orderId} AND type = 'order'
+        RETURNING id, properties, created_at
+      `;
+
+      const order = rowToOrder(rows[0]);
+      return new Response(JSON.stringify(order), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('PATCH /api/orders/:id ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  return null;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@
 import { migrate } from 'db';
 import { handleAuthRequest } from './api/auth';
 import { handleProductsRequest } from './api/products';
+import { handleOrdersRequest } from './api/orders';
 
 await migrate();
 
@@ -36,6 +37,11 @@ export default {
     if (url.pathname.startsWith('/api/products')) {
       const productsRes = await handleProductsRequest(req, url);
       if (productsRes) return productsRes;
+    }
+
+    if (url.pathname.startsWith('/api/orders')) {
+      const ordersRes = await handleOrdersRequest(req, url);
+      if (ordersRes) return ordersRes;
     }
 
     // Serve static assets — path is relative to this file, not process cwd

--- a/apps/server/tests/integration/orders.test.ts
+++ b/apps/server/tests/integration/orders.test.ts
@@ -1,0 +1,530 @@
+import { test, expect, beforeAll, afterAll } from 'vitest';
+import type { Subprocess } from 'bun';
+import { startPostgres, type PgContainer } from '../helpers/pg-container';
+
+const PORT = 31418;
+const BASE = `http://localhost:${PORT}`;
+const SERVER_READY_TIMEOUT_MS = 20_000;
+const REPO_ROOT = new URL('../../../../', import.meta.url).pathname;
+const SERVER_ENTRY = 'apps/server/src/index.ts';
+
+let pg: PgContainer;
+let server: Subprocess;
+let authCookie = '';
+let userId = '';
+
+beforeAll(async () => {
+  pg = await startPostgres();
+
+  server = Bun.spawn(['bun', 'run', SERVER_ENTRY], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, DATABASE_URL: pg.url, PORT: String(PORT) },
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+
+  await waitForServer(BASE);
+
+  // Register a test user and capture the session cookie
+  const username = `test_${Date.now()}`;
+  const res = await fetch(`${BASE}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password: 'testpass123' }),
+  });
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  authCookie = setCookie.split(';')[0];
+
+  const body = await res.json();
+  userId = body.user.id;
+}, 60_000);
+
+afterAll(async () => {
+  server?.kill();
+  await pg?.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: create a standard test product (Scenario 1 from PRD)
+// ---------------------------------------------------------------------------
+
+async function createTestProduct() {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: '4x4 Welded Wire Mesh 10ga',
+      sku: 'WM-4x4-10GA',
+      material: 'Galvanized Steel',
+      width_inches: 48,
+      length_inches: 120,
+      weight_per_sqft: 0.58,
+      cost_per_each: 32.0,
+      cost_per_linft: null,
+      cost_per_sqft: null,
+      primary_cost_basis: 'each',
+      margin_target: 25,
+      margin_floor: 15,
+    }),
+  });
+  expect(res.status).toBe(201);
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Auth guard tests
+// ---------------------------------------------------------------------------
+
+test('GET /api/orders returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/orders`);
+  expect(res.status).toBe(401);
+});
+
+test('POST /api/orders returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  expect(res.status).toBe(401);
+});
+
+test('PATCH /api/orders/:id returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/orders/some-id`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(res.status).toBe(401);
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/orders
+// ---------------------------------------------------------------------------
+
+test('GET /api/orders returns 200 with empty array initially', async () => {
+  const res = await fetch(`${BASE}/api/orders`, {
+    headers: { Cookie: authCookie },
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(Array.isArray(body)).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/orders — PRD Scenario 1
+// ---------------------------------------------------------------------------
+
+test('POST /api/orders with non-existent product_id returns 404', async () => {
+  const res = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Acme Fencing Co',
+      product_id: 'nonexistent-product-id',
+      quantity: 10,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(res.status).toBe(404);
+  const body = await res.json();
+  expect(body.error).toBeTruthy();
+});
+
+test('POST /api/orders computes correct fields matching PRD Scenario 1', async () => {
+  const product = await createTestProduct();
+
+  const res = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Acme Fencing Co',
+      product_id: product.id,
+      quantity: 10,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(res.status).toBe(201);
+  const order = await res.json();
+
+  expect(order.id).toBeTruthy();
+  expect(order.created_at).toBeTruthy();
+
+  const p = order.properties;
+  expect(p.customer).toBe('Acme Fencing Co');
+  expect(p.product_id).toBe(product.id);
+  expect(p.product_name).toBe('4x4 Welded Wire Mesh 10ga');
+  expect(p.quantity).toBe(10);
+  expect(p.unit_of_measure).toBe('each');
+  expect(p.sell_price_per_unit).toBe(45.0);
+  expect(p.status).toBe('draft');
+
+  // Conversions: 10 eaches, 100 linear feet, 400 square feet
+  expect(p.qty_eaches).toBe(10);
+  expect(p.qty_linft).toBe(100);
+  expect(p.qty_sqft).toBe(400);
+
+  // Economics: revenue=$450, cost=$320, margin=$130 (28.9%)
+  expect(p.total_revenue).toBe(450.0);
+  expect(p.total_cost).toBe(320.0);
+  expect(p.margin_dollars).toBe(130.0);
+  expect(p.margin_percent).toBeCloseTo(28.89, 1);
+
+  // Margin threshold snapshot from product
+  expect(p.margin_target).toBe(25);
+  expect(p.margin_floor).toBe(15);
+
+  // Audit fields
+  expect(p.created_by).toBe(userId);
+  expect(p.confirmed_by).toBeNull();
+  expect(p.confirmed_at).toBeNull();
+  expect(p.cancelled_by).toBeNull();
+  expect(p.cancelled_at).toBeNull();
+});
+
+test('POST /api/orders sets created_by from authenticated user', async () => {
+  const product = await createTestProduct();
+
+  const res = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Test Customer',
+      product_id: product.id,
+      quantity: 1,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 50.0,
+    }),
+  });
+  expect(res.status).toBe(201);
+  const order = await res.json();
+  expect(order.properties.created_by).toBe(userId);
+  expect(order.properties.status).toBe('draft');
+});
+
+test('POST /api/orders snapshots margin_target and margin_floor from product', async () => {
+  // Create a product with custom margin thresholds
+  const productRes = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      name: 'Custom Margin Product',
+      sku: 'CMP-001',
+      width_inches: 24,
+      length_inches: 60,
+      cost_per_each: 10.0,
+      primary_cost_basis: 'each',
+      margin_target: 30,
+      margin_floor: 20,
+    }),
+  });
+  expect(productRes.status).toBe(201);
+  const product = await productRes.json();
+
+  const res = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Margin Snapshot Test',
+      product_id: product.id,
+      quantity: 5,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 20.0,
+    }),
+  });
+  expect(res.status).toBe(201);
+  const order = await res.json();
+  expect(order.properties.margin_target).toBe(30);
+  expect(order.properties.margin_floor).toBe(20);
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/orders with filters
+// ---------------------------------------------------------------------------
+
+test('GET /api/orders returns created order in the list', async () => {
+  const product = await createTestProduct();
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Listed Order Customer',
+      product_id: product.id,
+      quantity: 2,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const created = await createRes.json();
+
+  const listRes = await fetch(`${BASE}/api/orders`, {
+    headers: { Cookie: authCookie },
+  });
+  expect(listRes.status).toBe(200);
+  const orders = await listRes.json();
+  const found = orders.find((o: { id: string }) => o.id === created.id);
+  expect(found).toBeTruthy();
+});
+
+test('GET /api/orders?status=draft filters by status', async () => {
+  const product = await createTestProduct();
+
+  // Create a draft order
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Draft Filter Customer',
+      product_id: product.id,
+      quantity: 3,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const draftOrder = await createRes.json();
+
+  // Filter by status=draft
+  const listRes = await fetch(`${BASE}/api/orders?status=draft`, {
+    headers: { Cookie: authCookie },
+  });
+  expect(listRes.status).toBe(200);
+  const orders = await listRes.json();
+
+  // All returned orders should be drafts
+  for (const o of orders) {
+    expect(o.properties.status).toBe('draft');
+  }
+
+  // Our order should be in the list
+  const found = orders.find((o: { id: string }) => o.id === draftOrder.id);
+  expect(found).toBeTruthy();
+});
+
+test('GET /api/orders?customer=Acme filters by customer (case-insensitive partial match)', async () => {
+  const product = await createTestProduct();
+
+  // Create an order with a distinctive customer name
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'AcmeFencing Special Customer',
+      product_id: product.id,
+      quantity: 1,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const acmeOrder = await createRes.json();
+
+  // Filter by customer=acmefencing (lowercase)
+  const listRes = await fetch(`${BASE}/api/orders?customer=acmefencing`, {
+    headers: { Cookie: authCookie },
+  });
+  expect(listRes.status).toBe(200);
+  const orders = await listRes.json();
+
+  // Our order should be in the list
+  const found = orders.find((o: { id: string }) => o.id === acmeOrder.id);
+  expect(found).toBeTruthy();
+
+  // All returned orders should match (case-insensitive)
+  for (const o of orders) {
+    expect(o.properties.customer.toLowerCase()).toContain('acmefencing');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/orders/:id — status transitions
+// ---------------------------------------------------------------------------
+
+test('PATCH /api/orders/:id with status=confirmed sets confirmed_by and confirmed_at', async () => {
+  const product = await createTestProduct();
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Confirm Test Customer',
+      product_id: product.id,
+      quantity: 5,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+  expect(order.properties.status).toBe('draft');
+
+  const patchRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(patchRes.status).toBe(200);
+  const updated = await patchRes.json();
+  expect(updated.properties.status).toBe('confirmed');
+  expect(updated.properties.confirmed_by).toBe(userId);
+  expect(updated.properties.confirmed_at).toBeTruthy();
+  expect(updated.properties.cancelled_by).toBeNull();
+  expect(updated.properties.cancelled_at).toBeNull();
+});
+
+test('PATCH /api/orders/:id with status=cancelled sets cancelled_by and cancelled_at', async () => {
+  const product = await createTestProduct();
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Cancel Test Customer',
+      product_id: product.id,
+      quantity: 2,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+
+  const patchRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'cancelled' }),
+  });
+  expect(patchRes.status).toBe(200);
+  const updated = await patchRes.json();
+  expect(updated.properties.status).toBe('cancelled');
+  expect(updated.properties.cancelled_by).toBe(userId);
+  expect(updated.properties.cancelled_at).toBeTruthy();
+});
+
+test('PATCH /api/orders/:id with invalid transition (confirmed->draft) returns 400', async () => {
+  const product = await createTestProduct();
+
+  // Create and confirm an order
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Invalid Transition Customer',
+      product_id: product.id,
+      quantity: 1,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+
+  // Confirm the order
+  const confirmRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(confirmRes.status).toBe(200);
+
+  // Try invalid transition: confirmed -> draft
+  const invalidRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'draft' }),
+  });
+  expect(invalidRes.status).toBe(400);
+  const body = await invalidRes.json();
+  expect(body.error).toBeTruthy();
+});
+
+test('PATCH /api/orders/:id cancelled->confirmed returns 400 (invalid transition)', async () => {
+  const product = await createTestProduct();
+
+  // Create and cancel an order
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Cancelled To Confirmed Customer',
+      product_id: product.id,
+      quantity: 1,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+
+  await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'cancelled' }),
+  });
+
+  // Try invalid transition: cancelled -> confirmed
+  const invalidRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(invalidRes.status).toBe(400);
+});
+
+test('PATCH /api/orders/:id updates notes without changing status', async () => {
+  const product = await createTestProduct();
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Notes Test Customer',
+      product_id: product.id,
+      quantity: 1,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+      notes: 'original notes',
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+
+  const patchRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ notes: 'updated notes' }),
+  });
+  expect(patchRes.status).toBe(200);
+  const updated = await patchRes.json();
+  expect(updated.properties.notes).toBe('updated notes');
+  expect(updated.properties.status).toBe('draft');
+});
+
+test('PATCH /api/orders/:id returns 404 for nonexistent order', async () => {
+  const res = await fetch(`${BASE}/api/orders/nonexistent-order-id`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(res.status).toBe(404);
+});
+
+// ---------------------------------------------------------------------------
+
+/** Poll the server until it responds or we time out. */
+async function waitForServer(base: string): Promise<void> {
+  const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${base}/api/auth/me`);
+      return;
+    } catch {
+      await Bun.sleep(300);
+    }
+  }
+  throw new Error(`Server at ${base} did not become ready within ${SERVER_READY_TIMEOUT_MS}ms`);
+}


### PR DESCRIPTION
## Summary

Implements #5.

Adds Orders API to `apps/server/src/api/orders.ts`:
- `GET /api/orders` — lists all orders ordered by `created_at DESC`, supports `?status=` and `?customer=` filters
- `POST /api/orders` — fetches product, calls `computeOrderFields()`, snapshots margin thresholds, sets `created_by` and `status='draft'`; returns 201
- `PATCH /api/orders/:id` — validates status transitions (`draft→confirmed`, `draft→cancelled`, `confirmed→cancelled`), sets audit fields, returns 400 for invalid transitions

All endpoints require authentication. Router wired in `apps/server/src/index.ts`.

14 integration tests cover all acceptance criteria: PRD Scenario 1 computed fields, 401 auth, 404 product not found, margin snapshot, status filters, confirm/cancel audit trail, invalid transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)