### PR TITLE
style: harmonize CSS design system across login and app

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,7 +35,7 @@ function App() {
       {/* Left Sidebar */}
       <nav className="w-16 shrink-0 border-r border-zinc-200 bg-white flex flex-col items-center py-6 justify-between z-10">
         <div className="flex flex-col items-center gap-6">
-          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center shadow-sm">
+          <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center shadow-sm">
             <span className="text-white font-black text-lg">M</span>
           </div>
 
@@ -45,7 +45,7 @@ function App() {
                 key={id}
                 onClick={() => setActiveView(id)}
                 title={label}
-                className={`p-3 rounded-xl flex items-center justify-center transition-all ${
+                className={`p-3 rounded-lg flex items-center justify-center transition-all ${
                   activeView === id
                     ? 'bg-emerald-50 text-emerald-600'
                     : 'text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600'
@@ -61,7 +61,7 @@ function App() {
           <button
             onClick={logout}
             title="Logout"
-            className="w-10 h-10 rounded-full bg-zinc-100 border border-zinc-200 flex items-center justify-center text-zinc-600 hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors focus:ring-2 focus:ring-offset-2 focus:ring-red-500 outline-none"
+            className="w-10 h-10 rounded-lg bg-zinc-100 border border-zinc-200 flex items-center justify-center text-zinc-600 hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors focus:ring-2 focus:ring-offset-2 focus:ring-red-500 outline-none"
           >
             <User size={18} />
           </button>

--- a/apps/web/src/components/Login.tsx
+++ b/apps/web/src/components/Login.tsx
@@ -89,10 +89,10 @@ export const Login: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center items-center font-sans">
-      <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-200 w-full max-w-md">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2 text-center">MeshMargin</h1>
-        <p className="text-gray-500 text-center mb-8">
+    <div className="min-h-screen bg-zinc-50 flex flex-col justify-center items-center font-sans">
+      <div className="bg-white p-8 rounded-lg shadow-sm border border-zinc-200 w-full max-w-md">
+        <h1 className="text-3xl font-bold text-zinc-900 mb-2 text-center">MeshMargin</h1>
+        <p className="text-zinc-500 text-center mb-8">
           {isRegister ? 'Create an account' : 'Sign in to your account'}
         </p>
 
@@ -104,22 +104,22 @@ export const Login: React.FC = () => {
 
         <form onSubmit={handleSubmit} className="space-y-5">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
+            <label className="block text-sm font-medium text-zinc-700 mb-1">Username</label>
             <input
               type="text"
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-shadow"
+              className="w-full px-4 py-3 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none transition-shadow"
               placeholder="e.g. jsmith"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+            <label className="block text-sm font-medium text-zinc-700 mb-1">Password</label>
             <input
               type="password"
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-shadow"
+              className="w-full px-4 py-3 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none transition-shadow"
               placeholder="••••••••"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -128,7 +128,7 @@ export const Login: React.FC = () => {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 rounded-lg transition-colors shadow-sm disabled:opacity-50"
+            className="w-full bg-zinc-800 hover:bg-zinc-900 text-white font-bold py-3 rounded-md transition-colors shadow-sm disabled:opacity-50"
           >
             {loading ? 'Authenticating...' : isRegister ? 'Create Account' : 'Sign In'}
           </button>
@@ -141,15 +141,15 @@ export const Login: React.FC = () => {
               setIsRegister(!isRegister);
               setError('');
             }}
-            className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+            className="text-zinc-700 hover:text-zinc-900 hover:underline transition-colors"
           >
             {isRegister ? 'Already have an account? Sign In' : 'Need an account? Register'}
           </button>
         </div>
 
         {DEMO_MODE && (
-          <div className="mt-6 pt-6 border-t border-gray-200">
-            <p className="text-sm text-gray-500 text-center mb-3">Demo accounts</p>
+          <div className="mt-6 pt-6 border-t border-zinc-200">
+            <p className="text-sm text-zinc-500 text-center mb-3">Demo accounts</p>
             <div className="flex gap-3">
               {DEMO_ACCOUNTS.map((account) => (
                 <button
@@ -157,7 +157,7 @@ export const Login: React.FC = () => {
                   type="button"
                   disabled={loading}
                   onClick={() => handleDemoLogin(account)}
-                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-2 px-4 rounded-lg transition-colors text-sm disabled:opacity-50"
+                  className="flex-1 bg-zinc-100 hover:bg-zinc-200 text-zinc-700 font-medium py-2 px-4 rounded-md transition-colors text-sm disabled:opacity-50"
                 >
                   {account.label}
                 </button>

--- a/apps/web/src/components/OrderEntry.tsx
+++ b/apps/web/src/components/OrderEntry.tsx
@@ -231,7 +231,7 @@ export const OrderEntry: React.FC = () => {
                     onChange={(e) => handleChange('customer', e.target.value)}
                     placeholder="Customer name"
                     tabIndex={1}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
                   />
                 </div>
 
@@ -247,7 +247,7 @@ export const OrderEntry: React.FC = () => {
                     value={form.productId}
                     onChange={(e) => handleChange('productId', e.target.value)}
                     tabIndex={2}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm bg-white"
+                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm bg-white"
                   >
                     <option value="">Select a product...</option>
                     {products.map((p) => (
@@ -275,7 +275,7 @@ export const OrderEntry: React.FC = () => {
                       onChange={(e) => handleChange('quantity', e.target.value)}
                       placeholder="0"
                       tabIndex={3}
-                      className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                      className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
                     />
                   </div>
                   <div>
@@ -290,7 +290,7 @@ export const OrderEntry: React.FC = () => {
                       value={form.uom}
                       onChange={(e) => handleChange('uom', e.target.value as UnitOfMeasure)}
                       tabIndex={4}
-                      className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm bg-white"
+                      className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm bg-white"
                     >
                       {UOM_OPTIONS.map((opt) => (
                         <option key={opt.value} value={opt.value}>
@@ -317,7 +317,7 @@ export const OrderEntry: React.FC = () => {
                     onChange={(e) => handleChange('sellPrice', e.target.value)}
                     placeholder="0.00"
                     tabIndex={5}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
                   />
                 </div>
 
@@ -334,7 +334,7 @@ export const OrderEntry: React.FC = () => {
                     onChange={(e) => handleChange('notes', e.target.value)}
                     placeholder="Notes about this order..."
                     rows={3}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm resize-none"
+                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm resize-none"
                   />
                 </div>
 
@@ -342,7 +342,7 @@ export const OrderEntry: React.FC = () => {
                   type="submit"
                   tabIndex={6}
                   disabled={submitting || !selectedProduct || !hasQty || !hasPrice}
-                  className="w-full px-4 py-2.5 text-sm font-semibold text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="w-full px-4 py-2.5 text-sm font-semibold text-white bg-zinc-800 hover:bg-zinc-900 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {submitting ? 'Submitting...' : 'Confirm Order'}
                 </button>
@@ -353,7 +353,7 @@ export const OrderEntry: React.FC = () => {
                 {selectedProduct ? (
                   <>
                     {/* Product context */}
-                    <div className="bg-zinc-50 rounded-xl border border-zinc-200 p-4">
+                    <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
                       <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1">
                         Product Context
                       </p>
@@ -364,7 +364,7 @@ export const OrderEntry: React.FC = () => {
 
                     {/* Unit conversions */}
                     {computed ? (
-                      <div className="bg-zinc-50 rounded-xl border border-zinc-200 p-4 space-y-2">
+                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4 space-y-2">
                         <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
                           Unit Conversions
                         </p>
@@ -394,7 +394,7 @@ export const OrderEntry: React.FC = () => {
                         )}
                       </div>
                     ) : (
-                      <div className="bg-zinc-50 rounded-xl border border-zinc-200 p-4">
+                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
                         <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
                           Unit Conversions
                         </p>
@@ -406,7 +406,7 @@ export const OrderEntry: React.FC = () => {
 
                     {/* Cost & Margin */}
                     {computed ? (
-                      <div className="bg-zinc-50 rounded-xl border border-zinc-200 p-4 space-y-2">
+                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4 space-y-2">
                         <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
                           Cost & Margin
                         </p>
@@ -424,7 +424,7 @@ export const OrderEntry: React.FC = () => {
                         </div>
 
                         {/* Margin display */}
-                        <div className={`mt-3 rounded-xl border-2 p-4 ${marginClass}`}>
+                        <div className={`mt-3 rounded-lg border-2 p-4 ${marginClass}`}>
                           <p className="text-xs font-semibold uppercase tracking-wide opacity-70 mb-1">
                             Margin
                           </p>
@@ -439,7 +439,7 @@ export const OrderEntry: React.FC = () => {
                         </div>
                       </div>
                     ) : (
-                      <div className="bg-zinc-50 rounded-xl border border-zinc-200 p-4">
+                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
                         <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
                           Cost & Margin
                         </p>

--- a/apps/web/src/components/OrderHistory.tsx
+++ b/apps/web/src/components/OrderHistory.tsx
@@ -78,18 +78,18 @@ interface ConfirmDialogProps {
 function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogProps) {
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-sm p-6">
         <p className="text-sm text-zinc-700 mb-6">{message}</p>
         <div className="flex justify-end gap-3">
           <button
             onClick={onCancel}
-            className="px-4 py-2 text-sm font-medium text-zinc-700 bg-zinc-100 hover:bg-zinc-200 rounded-lg transition-colors"
+            className="px-4 py-2 text-sm font-medium text-zinc-700 bg-zinc-100 hover:bg-zinc-200 rounded-md transition-colors"
           >
             Go back
           </button>
           <button
             onClick={onConfirm}
-            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md transition-colors"
           >
             Confirm cancellation
           </button>
@@ -215,7 +215,7 @@ export const OrderHistory: React.FC = () => {
             onChange={(e) => setCustomerFilter(e.target.value)}
             placeholder="Filter by customer..."
             aria-label="Filter by customer"
-            className="px-3 py-1.5 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm w-48"
+            className="px-3 py-1.5 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm w-48"
           />
         </div>
       </div>
@@ -250,7 +250,7 @@ export const OrderHistory: React.FC = () => {
 
       {/* Table */}
       {!loading && !error && orders.length > 0 && (
-        <div className="overflow-x-auto rounded-xl border border-zinc-200 bg-white">
+        <div className="overflow-x-auto rounded-lg border border-zinc-200 bg-white">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-zinc-200 bg-zinc-50">
@@ -315,7 +315,7 @@ export const OrderHistory: React.FC = () => {
                     </td>
                     <td className="px-4 py-3">
                       <span
-                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium ${
                           p.status === 'confirmed'
                             ? 'bg-emerald-100 text-emerald-800'
                             : p.status === 'cancelled'

--- a/apps/web/src/components/ProductCatalog.tsx
+++ b/apps/web/src/components/ProductCatalog.tsx
@@ -162,7 +162,7 @@ function ProductModal({
 
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-auto">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-auto">
         <div className="flex items-center justify-between p-5 border-b border-zinc-200">
           <h2 className="text-lg font-semibold text-zinc-900">
             {editingProduct ? 'Edit Product' : 'Add Product'}
@@ -194,7 +194,7 @@ function ProductModal({
                 value={form.name}
                 onChange={(e) => handleChange('name', e.target.value)}
                 placeholder="Product name"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
             <div>
@@ -204,7 +204,7 @@ function ProductModal({
                 value={form.sku}
                 onChange={(e) => handleChange('sku', e.target.value)}
                 placeholder="SKU code"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
           </div>
@@ -216,7 +216,7 @@ function ProductModal({
               value={form.material}
               onChange={(e) => handleChange('material', e.target.value)}
               placeholder="Material type"
-              className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+              className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
             />
           </div>
 
@@ -232,7 +232,7 @@ function ProductModal({
                 value={form.width_inches}
                 onChange={(e) => handleChange('width_inches', e.target.value)}
                 placeholder="0"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
             <div>
@@ -249,7 +249,7 @@ function ProductModal({
                 value={form.length_inches}
                 onChange={(e) => handleChange('length_inches', e.target.value)}
                 placeholder="0"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
             <div>
@@ -262,7 +262,7 @@ function ProductModal({
                 value={form.weight_per_sqft}
                 onChange={(e) => handleChange('weight_per_sqft', e.target.value)}
                 placeholder="0"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
           </div>
@@ -274,7 +274,7 @@ function ProductModal({
             <select
               value={form.primary_cost_basis}
               onChange={(e) => handleChange('primary_cost_basis', e.target.value)}
-              className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm bg-white"
+              className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm bg-white"
             >
               {COST_BASIS_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -299,7 +299,7 @@ function ProductModal({
                 value={form.cost_per_each}
                 onChange={(e) => handleChange('cost_per_each', e.target.value)}
                 placeholder="—"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
             <div>
@@ -312,7 +312,7 @@ function ProductModal({
                 value={form.cost_per_linft}
                 onChange={(e) => handleChange('cost_per_linft', e.target.value)}
                 placeholder="—"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
             <div>
@@ -325,7 +325,7 @@ function ProductModal({
                 value={form.cost_per_sqft}
                 onChange={(e) => handleChange('cost_per_sqft', e.target.value)}
                 placeholder="—"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
           </div>
@@ -341,7 +341,7 @@ function ProductModal({
                 value={form.margin_target}
                 onChange={(e) => handleChange('margin_target', e.target.value)}
                 placeholder="25"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
             <div>
@@ -354,7 +354,7 @@ function ProductModal({
                 value={form.margin_floor}
                 onChange={(e) => handleChange('margin_floor', e.target.value)}
                 placeholder="15"
-                className="w-full px-3 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none text-sm"
+                className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
               />
             </div>
           </div>
@@ -363,14 +363,14 @@ function ProductModal({
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-zinc-700 bg-zinc-100 hover:bg-zinc-200 rounded-lg transition-colors"
+              className="px-4 py-2 text-sm font-medium text-zinc-700 bg-zinc-100 hover:bg-zinc-200 rounded-md transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={submitting}
-              className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg transition-colors disabled:opacity-50"
+              className="px-4 py-2 text-sm font-medium text-white bg-zinc-800 hover:bg-zinc-900 rounded-md transition-colors disabled:opacity-50"
             >
               {submitting ? 'Saving...' : 'Save'}
             </button>
@@ -446,7 +446,7 @@ export const ProductCatalog: React.FC = () => {
         <h2 className="text-lg font-semibold text-zinc-900">Product Catalog</h2>
         <button
           onClick={openAdd}
-          className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg transition-colors"
+          className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-zinc-800 hover:bg-zinc-900 rounded-md transition-colors"
         >
           <Plus size={16} />
           Add Product
@@ -458,7 +458,7 @@ export const ProductCatalog: React.FC = () => {
           No products yet. Click &quot;Add Product&quot; to get started.
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-zinc-200 bg-white">
+        <div className="overflow-x-auto rounded-lg border border-zinc-200 bg-white">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-zinc-200 bg-zinc-50">


### PR DESCRIPTION
## Summary

Implements #23 — CSS design system harmonization across login and app.

- **Neutral palette**: all `gray-*` replaced with `zinc-*` throughout — login and app now share the same neutral scale
- **Primary buttons**: `blue-600`/`emerald-600` on chrome → `zinc-800`/`zinc-900` for a professional, understated dark tone
- **Focus rings**: unified to `zinc-900` across all form inputs (was blue on login, emerald on app)
- **Border radius**: reduced and standardized — buttons/inputs `rounded-md`, containers `rounded-lg`, modals `rounded-lg`; removed all `rounded-2xl` and `rounded-full` from non-circular elements
- **Semantic colors preserved**: emerald/amber/red margin indicators untouched

Files changed: `Login.tsx`, `App.tsx`, `OrderEntry.tsx`, `OrderHistory.tsx`, `ProductCatalog.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)