### PR TITLE
feat: expand demo seed data with varied wire mesh roll sizes

### DIFF
--- a/packages/db/seed.ts
+++ b/packages/db/seed.ts
@@ -7,7 +7,44 @@ import postgres from 'postgres';
  * Safe to call on every server startup.
  */
 
-const WIRE_MESH_SKU = 'WM-4X4-10GA';
+const WIRE_MESH_PRODUCTS = [
+  {
+    sku: 'WM-4X4-10GA',
+    name: '4x4 Welded Wire Mesh - 10ga',
+    width_inches: 48,
+    length_inches: 120,
+    cost_per_each: 32.0,
+  },
+  {
+    sku: 'WM-4X4-10GA-36X96',
+    name: '4x4 Welded Wire Mesh - 10ga 36"×96"',
+    width_inches: 36,
+    length_inches: 96,
+    cost_per_each: 19.2,
+  },
+  {
+    sku: 'WM-4X4-10GA-60X120',
+    name: '4x4 Welded Wire Mesh - 10ga 60"×120"',
+    width_inches: 60,
+    length_inches: 120,
+    cost_per_each: 40.0,
+  },
+  {
+    sku: 'WM-4X4-10GA-48X240',
+    name: '4x4 Welded Wire Mesh - 10ga 48"×240"',
+    width_inches: 48,
+    length_inches: 240,
+    cost_per_each: 64.0,
+  },
+  {
+    sku: 'WM-4X4-10GA-60X240',
+    name: '4x4 Welded Wire Mesh - 10ga 60"×240"',
+    width_inches: 60,
+    length_inches: 240,
+    cost_per_each: 80.0,
+  },
+] as const;
+
 const DEMO_USERS = [
   { username: 'sales_rep', password: 'demo1234' },
   { username: 'order_clerk', password: 'demo1234' },
@@ -40,38 +77,40 @@ export async function seed(sqlConn: postgres.Sql, options: SeedOptions = {}): Pr
 }
 
 async function seedProduct(db: postgres.Sql): Promise<void> {
-  const existing = await db`
-    SELECT id FROM entities
-    WHERE type = 'product' AND properties->>'sku' = ${WIRE_MESH_SKU}
-  `;
+  for (const product of WIRE_MESH_PRODUCTS) {
+    const existing = await db`
+      SELECT id FROM entities
+      WHERE type = 'product' AND properties->>'sku' = ${product.sku}
+    `;
 
-  if (existing.length > 0) {
-    console.log('[seed] Wire Mesh product already exists, skipping.');
-    return;
+    if (existing.length > 0) {
+      console.log(`[seed] Product "${product.sku}" already exists, skipping.`);
+      continue;
+    }
+
+    const id = crypto.randomUUID();
+    const properties = {
+      name: product.name,
+      sku: product.sku,
+      material: 'Galvanized Steel',
+      width_inches: product.width_inches,
+      length_inches: product.length_inches,
+      weight_per_sqft: 0.58,
+      cost_per_each: product.cost_per_each,
+      cost_per_linft: null,
+      cost_per_sqft: null,
+      primary_cost_basis: 'each',
+      margin_target: 25,
+      margin_floor: 15,
+    };
+
+    await db`
+      INSERT INTO entities (id, type, properties, tenant_id)
+      VALUES (${id}, 'product', ${db.json(properties)}, null)
+    `;
+
+    console.log(`[seed] Inserted product "${product.sku}".`);
   }
-
-  const id = crypto.randomUUID();
-  const properties = {
-    name: '4x4 Welded Wire Mesh - 10ga',
-    sku: WIRE_MESH_SKU,
-    material: 'Galvanized Steel',
-    width_inches: 48,
-    length_inches: 120,
-    weight_per_sqft: 0.58,
-    cost_per_each: 32.0,
-    cost_per_linft: null,
-    cost_per_sqft: null,
-    primary_cost_basis: 'each',
-    margin_target: 25,
-    margin_floor: 15,
-  };
-
-  await db`
-    INSERT INTO entities (id, type, properties, tenant_id)
-    VALUES (${id}, 'product', ${db.json(properties)}, null)
-  `;
-
-  console.log('[seed] Inserted Wire Mesh product.');
 }
 
 async function seedUsers(db: postgres.Sql): Promise<void> {


### PR DESCRIPTION
## Summary

Implements #34.

Adds 4 additional wire mesh roll products to the demo seed alongside the existing WM-4X4-10GA:

| SKU | Width | Length | Cost/each |
|-----|-------|--------|-----------|
| WM-4X4-10GA | 48" | 120" | $32.00 (existing) |
| WM-4X4-10GA-36X96 | 36" | 96" | $19.20 |
| WM-4X4-10GA-60X120 | 60" | 120" | $40.00 |
| WM-4X4-10GA-48X240 | 48" | 240" | $64.00 |
| WM-4X4-10GA-60X240 | 60" | 240" | $80.00 |

Costs are scaled proportionally to area relative to the base product. Seed remains idempotent — each product is checked by SKU before insertion.

## Status

🚧 Work in progress

## Test plan

See #34 for acceptance criteria and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)