### PR TITLE
feat: add branding flourish to login page

### DIFF
--- a/apps/web/src/components/Login.tsx
+++ b/apps/web/src/components/Login.tsx
@@ -90,6 +90,10 @@ export const Login: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-zinc-50 flex flex-col justify-center items-center font-sans">
+      <div className="text-center mb-8">
+        <h1 className="text-5xl font-bold text-zinc-900 mb-2">The Wire.</h1>
+        <h3 className="text-xl font-medium text-zinc-500">Pricing Season</h3>
+      </div>
       <div className="bg-white p-8 rounded-lg shadow-sm border border-zinc-200 w-full max-w-md">
         <h1 className="text-3xl font-bold text-zinc-900 mb-2 text-center">MeshMargin</h1>
         <p className="text-zinc-500 text-center mb-8">


### PR DESCRIPTION
## Summary

Implements #35.

Adds a centered branding header above the login form in `apps/web/src/components/Login.tsx`:

- `h1` "The Wire." — `text-5xl font-bold text-zinc-900`
- `h3` "Pricing Season" — `text-xl font-medium text-zinc-500`

Both wrapped in a `text-center mb-8` div, consistent with the existing zinc design system. The login form and "MeshMargin" product name are unchanged.

## Test plan

See #35 for acceptance criteria and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)