### PR TITLE
feat: width-match quote flow in order entry

### DIFF
--- a/apps/web/src/components/OrderEntry.tsx
+++ b/apps/web/src/components/OrderEntry.tsx
@@ -1,11 +1,28 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type { Product, UnitOfMeasure } from 'core';
-import { evaluateMargin, calculateCost, convertUnits, calculateMargin } from 'core';
+import {
+  evaluateMargin,
+  calculateCost,
+  convertUnits,
+  calculateMargin,
+  findBundlesByWidth,
+} from 'core';
+import type { Bundle } from 'core';
 
 const UOM_OPTIONS: { value: UnitOfMeasure; label: string }[] = [
   { value: 'square_foot', label: 'Square ft' },
   { value: 'linear_foot', label: 'Linear ft' },
 ];
+
+type OrderMode = 'by-product' | 'by-width' | 'by-area';
+
+const MODE_TABS: { value: OrderMode; label: string }[] = [
+  { value: 'by-product', label: 'By Product' },
+  { value: 'by-width', label: 'By Width' },
+  { value: 'by-area', label: 'By Area' },
+];
+
+type BundleSortKey = 'price-sqft' | 'price-linft';
 
 function targetMarginPricePerEach(product: Product): string {
   const costPerEach = product.properties.cost_per_each ?? 0;
@@ -56,10 +73,297 @@ function formatPercent(value: number): string {
   });
 }
 
+// --- By Width mode ---
+
+interface WidthInputs {
+  width: string;
+  length: string;
+  sellPrice: string;
+}
+
+const EMPTY_WIDTH_INPUTS: WidthInputs = {
+  width: '',
+  length: '',
+  sellPrice: '',
+};
+
+interface BundleCardProps {
+  bundle: Bundle;
+  sellPricePerUnit: number;
+  onSelectForQuote: (bundle: Bundle, sellPrice: number) => void;
+}
+
+function BundleCard({ bundle, sellPricePerUnit, onSelectForQuote }: BundleCardProps) {
+  const { product, quantity, totalLinft, totalSqft, overage } = bundle;
+  const p = product.properties;
+
+  const totalRevenue = sellPricePerUnit * quantity;
+  const costTotal = bundle.costTotal;
+  const { dollars: marginDollars, percent: marginPercent } = calculateMargin(
+    totalRevenue,
+    costTotal,
+  );
+  const marginHealth = evaluateMargin(marginPercent, p.margin_target, p.margin_floor);
+
+  const customerPricePerSqft = totalSqft === 0 ? 0 : totalRevenue / totalSqft;
+  const customerPricePerLinft = totalLinft === 0 ? 0 : totalRevenue / totalLinft;
+
+  const overageLinft = overage / (p.width_inches / 12);
+
+  const marginColorClasses: Record<string, string> = {
+    healthy: 'bg-emerald-50 border-emerald-400 text-emerald-800',
+    warning: 'bg-amber-50 border-amber-400 text-amber-800',
+    critical: 'bg-red-50 border-red-400 text-red-800',
+  };
+  const marginTextClasses: Record<string, string> = {
+    healthy: 'text-emerald-700',
+    warning: 'text-amber-700',
+    critical: 'text-red-700',
+  };
+
+  const marginClass = marginColorClasses[marginHealth];
+  const marginTextClass = marginTextClasses[marginHealth];
+
+  const overageLinftRounded = Math.round(overageLinft * 10) / 10;
+  const overageLabel =
+    overageLinftRounded <= 0 ? 'no waste' : `${formatNumber(overageLinftRounded, 1)} ft overage`;
+
+  return (
+    <div className="bg-white border border-zinc-200 rounded-lg p-4 space-y-3">
+      {/* Header: product name + SKU */}
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold text-zinc-900">{p.name}</p>
+          <p className="text-xs text-zinc-500">{p.sku}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onSelectForQuote(bundle, sellPricePerUnit)}
+          className="shrink-0 px-3 py-1.5 text-xs font-semibold text-white bg-zinc-800 hover:bg-zinc-900 rounded-md transition-colors"
+        >
+          Select for Quote
+        </button>
+      </div>
+
+      {/* Quantity + delivery */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+        <span className="text-zinc-700">
+          <span className="font-medium">{quantity}</span> rolls
+        </span>
+        <span className="text-zinc-500">
+          {formatNumber(totalLinft, 0)} ft — {overageLabel}
+        </span>
+      </div>
+
+      {/* Customer pricing */}
+      {sellPricePerUnit > 0 && (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-zinc-700">
+          <span>
+            <span className="font-medium">${customerPricePerSqft.toFixed(2)}</span>
+            <span className="text-zinc-500"> / sqft</span>
+          </span>
+          <span>
+            <span className="font-medium">${customerPricePerLinft.toFixed(2)}</span>
+            <span className="text-zinc-500"> / linft</span>
+          </span>
+        </div>
+      )}
+
+      {/* Margin — rep only */}
+      {sellPricePerUnit > 0 && (
+        <div className={`rounded-md border px-3 py-2 ${marginClass}`}>
+          <div className="flex items-baseline gap-3">
+            <span className={`text-sm font-bold ${marginTextClass}`}>
+              {formatCurrency(marginDollars)}
+            </span>
+            <span className={`text-sm font-semibold ${marginTextClass}`}>
+              {formatPercent(marginPercent)}%
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ByWidthPanelProps {
+  products: Product[];
+  onSelectForQuote: (productId: string, quantity: number, sellPrice: number) => void;
+}
+
+function ByWidthPanel({ products, onSelectForQuote }: ByWidthPanelProps) {
+  const [inputs, setInputs] = useState<WidthInputs>({ ...EMPTY_WIDTH_INPUTS });
+  const [sortKey, setSortKey] = useState<BundleSortKey>('price-sqft');
+
+  const widthInches = parseFloat(inputs.width);
+  const lengthFeet = parseFloat(inputs.length);
+  const sellPricePerUnit = parseFloat(inputs.sellPrice);
+
+  const hasWidth = !isNaN(widthInches) && widthInches > 0;
+  const hasLength = !isNaN(lengthFeet) && lengthFeet > 0;
+  const hasSellPrice = !isNaN(sellPricePerUnit) && sellPricePerUnit >= 0;
+
+  const rawBundles: Bundle[] = useMemo(() => {
+    if (!hasWidth || !hasLength) return [];
+    const totalLengthInches = lengthFeet * 12;
+    return findBundlesByWidth(products, widthInches, totalLengthInches);
+  }, [products, widthInches, lengthFeet, hasWidth, hasLength]);
+
+  const sortedBundles: Bundle[] = useMemo(() => {
+    if (rawBundles.length === 0 || !hasSellPrice || sellPricePerUnit === 0) {
+      return rawBundles;
+    }
+    const copy = [...rawBundles];
+    if (sortKey === 'price-sqft') {
+      copy.sort((a, b) => {
+        const aPricePerSqft = a.totalSqft === 0 ? 0 : (sellPricePerUnit * a.quantity) / a.totalSqft;
+        const bPricePerSqft = b.totalSqft === 0 ? 0 : (sellPricePerUnit * b.quantity) / b.totalSqft;
+        return aPricePerSqft - bPricePerSqft;
+      });
+    } else {
+      copy.sort((a, b) => {
+        const aPricePerLinft =
+          a.totalLinft === 0 ? 0 : (sellPricePerUnit * a.quantity) / a.totalLinft;
+        const bPricePerLinft =
+          b.totalLinft === 0 ? 0 : (sellPricePerUnit * b.quantity) / b.totalLinft;
+        return aPricePerLinft - bPricePerLinft;
+      });
+    }
+    return copy;
+  }, [rawBundles, sortKey, sellPricePerUnit, hasSellPrice]);
+
+  const handleInputChange = (field: keyof WidthInputs, value: string) => {
+    setInputs((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSelectForQuote = (bundle: Bundle, sellPrice: number) => {
+    onSelectForQuote(bundle.product.id, bundle.quantity, sellPrice);
+  };
+
+  const showEmptyState = hasWidth && hasLength && rawBundles.length === 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Inputs row */}
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <label
+            htmlFor="width-input-width"
+            className="block text-sm font-medium text-zinc-700 mb-1"
+          >
+            Width (inches)
+          </label>
+          <input
+            id="width-input-width"
+            type="number"
+            step="any"
+            min="0"
+            value={inputs.width}
+            onChange={(e) => handleInputChange('width', e.target.value)}
+            placeholder="48"
+            className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="width-input-length"
+            className="block text-sm font-medium text-zinc-700 mb-1"
+          >
+            Total Length (feet)
+          </label>
+          <input
+            id="width-input-length"
+            type="number"
+            step="any"
+            min="0"
+            value={inputs.length}
+            onChange={(e) => handleInputChange('length', e.target.value)}
+            placeholder="200"
+            className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="width-input-sell-price"
+            className="block text-sm font-medium text-zinc-700 mb-1"
+          >
+            Sell price per unit ($)
+          </label>
+          <input
+            id="width-input-sell-price"
+            type="number"
+            step="0.01"
+            min="0"
+            value={inputs.sellPrice}
+            onChange={(e) => handleInputChange('sellPrice', e.target.value)}
+            placeholder="0.00"
+            className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
+          />
+        </div>
+      </div>
+
+      {/* Empty state */}
+      {showEmptyState && (
+        <div className="bg-zinc-50 border border-zinc-200 rounded-lg p-6 text-center">
+          <p className="text-sm text-zinc-500">No products available at {widthInches}&quot;</p>
+        </div>
+      )}
+
+      {/* Bundle list */}
+      {sortedBundles.length > 0 && (
+        <div className="space-y-3">
+          {/* Sort controls */}
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-zinc-500">Sort by:</span>
+            <button
+              type="button"
+              onClick={() => setSortKey('price-sqft')}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                sortKey === 'price-sqft'
+                  ? 'bg-zinc-800 text-white'
+                  : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200'
+              }`}
+            >
+              Price/sqft ↑
+            </button>
+            <button
+              type="button"
+              onClick={() => setSortKey('price-linft')}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                sortKey === 'price-linft'
+                  ? 'bg-zinc-800 text-white'
+                  : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200'
+              }`}
+            >
+              Price/linft ↑
+            </button>
+          </div>
+
+          {/* Bundle cards */}
+          {sortedBundles.map((bundle) => (
+            <BundleCard
+              key={bundle.product.id}
+              bundle={bundle}
+              sellPricePerUnit={hasSellPrice ? sellPricePerUnit : 0}
+              onSelectForQuote={handleSelectForQuote}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export const OrderEntry: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);
   const [loadingProducts, setLoadingProducts] = useState(true);
   const [productError, setProductError] = useState<string | null>(null);
+
+  const [mode, setMode] = useState<OrderMode>('by-product');
+
+  // Tracks whether the current product selection came from "Select for Quote".
+  // When true, skip the auto-seed of sell price so the quoted price is preserved.
+  const skipSellPriceSeedRef = useRef(false);
 
   const [form, setForm] = useState<OrderForm>({ ...EMPTY_FORM });
   const [submitting, setSubmitting] = useState(false);
@@ -87,9 +391,14 @@ export const OrderEntry: React.FC = () => {
 
   const selectedProduct = products.find((p) => p.id === form.productId) ?? null;
 
-  // When product changes, seed sell price with the target-margin per-each rate
+  // When product changes, seed sell price with the target-margin per-each rate.
+  // Skip seeding when a quoted price was pre-filled via "Select for Quote".
   useEffect(() => {
     if (selectedProduct) {
+      if (skipSellPriceSeedRef.current) {
+        skipSellPriceSeedRef.current = false;
+        return;
+      }
       setForm((prev) => ({ ...prev, sellPrice: targetMarginPricePerEach(selectedProduct) }));
     }
   }, [selectedProduct]);
@@ -215,6 +524,23 @@ export const OrderEntry: React.FC = () => {
     }
   };
 
+  // Called by ByWidthPanel when rep clicks "Select for Quote"
+  const handleSelectForQuote = (productId: string, quantity: number, sellPrice: number) => {
+    if (sellPrice > 0) {
+      skipSellPriceSeedRef.current = true;
+    }
+    setMode('by-product');
+    setForm((prev) => ({
+      ...prev,
+      productId,
+      quantity: quantity.toString(),
+      uom: 'each',
+      sellPrice: sellPrice > 0 ? sellPrice.toFixed(2) : prev.sellPrice,
+    }));
+    setSubmitError(null);
+    setSuccessMessage(null);
+  };
+
   const marginColorClasses: Record<string, string> = {
     healthy: 'bg-emerald-50 border-emerald-400 text-emerald-800',
     warning: 'bg-amber-50 border-amber-400 text-amber-800',
@@ -269,268 +595,298 @@ export const OrderEntry: React.FC = () => {
             </div>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <div className="grid grid-cols-2 gap-6">
-              {/* Left column: inputs */}
-              <div className="space-y-4">
-                <div>
-                  <label
-                    htmlFor="field-customer"
-                    className="block text-sm font-medium text-zinc-700 mb-1"
-                  >
-                    Customer
-                  </label>
-                  <input
-                    id="field-customer"
-                    type="text"
-                    value={form.customer}
-                    onChange={(e) => handleChange('customer', e.target.value)}
-                    placeholder="Customer name"
-                    tabIndex={1}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
-                  />
-                </div>
+          {/* Mode selector */}
+          <div className="flex gap-1 mb-6 bg-zinc-100 rounded-lg p-1 w-fit">
+            {MODE_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                type="button"
+                onClick={() => setMode(tab.value)}
+                className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  mode === tab.value
+                    ? 'bg-white text-zinc-900 shadow-sm'
+                    : 'text-zinc-600 hover:text-zinc-900'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
 
-                <div>
-                  <label
-                    htmlFor="field-product"
-                    className="block text-sm font-medium text-zinc-700 mb-1"
-                  >
-                    Product
-                  </label>
-                  <select
-                    id="field-product"
-                    value={form.productId}
-                    onChange={(e) => handleChange('productId', e.target.value)}
-                    tabIndex={2}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm bg-white"
-                  >
-                    <option value="">Select a product...</option>
-                    {products.map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {p.properties.name} ({p.properties.sku})
-                      </option>
-                    ))}
-                  </select>
-                </div>
+          {mode === 'by-width' && (
+            <ByWidthPanel products={products} onSelectForQuote={handleSelectForQuote} />
+          )}
 
-                <div className="grid grid-cols-2 gap-3">
+          {mode === 'by-area' && (
+            <div className="bg-zinc-50 border border-zinc-200 rounded-lg p-6 text-center">
+              <p className="text-sm text-zinc-500">Square footage quote flow coming soon.</p>
+            </div>
+          )}
+
+          {mode === 'by-product' && (
+            <form onSubmit={handleSubmit}>
+              <div className="grid grid-cols-2 gap-6">
+                {/* Left column: inputs */}
+                <div className="space-y-4">
                   <div>
                     <label
-                      htmlFor="field-quantity"
+                      htmlFor="field-customer"
                       className="block text-sm font-medium text-zinc-700 mb-1"
                     >
-                      Quantity
+                      Customer
                     </label>
                     <input
-                      id="field-quantity"
-                      type="number"
-                      step="any"
-                      min="0"
-                      value={form.quantity}
-                      onChange={(e) => handleChange('quantity', e.target.value)}
-                      placeholder="0"
-                      tabIndex={3}
+                      id="field-customer"
+                      type="text"
+                      value={form.customer}
+                      onChange={(e) => handleChange('customer', e.target.value)}
+                      placeholder="Customer name"
+                      tabIndex={1}
                       className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
                     />
                   </div>
+
                   <div>
                     <label
-                      htmlFor="field-uom"
+                      htmlFor="field-product"
                       className="block text-sm font-medium text-zinc-700 mb-1"
                     >
-                      Unit of measure
+                      Product
                     </label>
                     <select
-                      id="field-uom"
-                      value={form.uom}
-                      onChange={(e) => handleChange('uom', e.target.value as UnitOfMeasure)}
-                      tabIndex={4}
+                      id="field-product"
+                      value={form.productId}
+                      onChange={(e) => handleChange('productId', e.target.value)}
+                      tabIndex={2}
                       className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm bg-white"
                     >
-                      {UOM_OPTIONS.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                          {opt.label}
+                      <option value="">Select a product...</option>
+                      {products.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.properties.name} ({p.properties.sku})
                         </option>
                       ))}
                     </select>
                   </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label
+                        htmlFor="field-quantity"
+                        className="block text-sm font-medium text-zinc-700 mb-1"
+                      >
+                        Quantity
+                      </label>
+                      <input
+                        id="field-quantity"
+                        type="number"
+                        step="any"
+                        min="0"
+                        value={form.quantity}
+                        onChange={(e) => handleChange('quantity', e.target.value)}
+                        placeholder="0"
+                        tabIndex={3}
+                        className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="field-uom"
+                        className="block text-sm font-medium text-zinc-700 mb-1"
+                      >
+                        Unit of measure
+                      </label>
+                      <select
+                        id="field-uom"
+                        value={form.uom}
+                        onChange={(e) => handleChange('uom', e.target.value as UnitOfMeasure)}
+                        tabIndex={4}
+                        className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm bg-white"
+                      >
+                        {UOM_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="field-sell-price"
+                      className="block text-sm font-medium text-zinc-700 mb-1"
+                    >
+                      Sell price per each ($)
+                    </label>
+                    <input
+                      id="field-sell-price"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={form.sellPrice}
+                      onChange={(e) => handleChange('sellPrice', e.target.value)}
+                      placeholder="0.00"
+                      tabIndex={5}
+                      className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
+                    />
+                    {equivalentRates && (
+                      <p className="mt-1 text-xs text-zinc-500">
+                        {`\u2248 $${equivalentRates.pricePerSqft.toFixed(2)} / sqft \u00b7 $${equivalentRates.pricePerLinft.toFixed(2)} / linft`}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="field-notes"
+                      className="block text-sm font-medium text-zinc-700 mb-1"
+                    >
+                      Notes (optional)
+                    </label>
+                    <textarea
+                      id="field-notes"
+                      value={form.notes}
+                      onChange={(e) => handleChange('notes', e.target.value)}
+                      placeholder="Notes about this order..."
+                      rows={3}
+                      className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm resize-none"
+                    />
+                  </div>
+
+                  <button
+                    type="submit"
+                    tabIndex={6}
+                    disabled={submitting || !selectedProduct || !hasQty || !hasPrice}
+                    className="w-full px-4 py-2.5 text-sm font-semibold text-white bg-zinc-800 hover:bg-zinc-900 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {submitting ? 'Submitting...' : 'Confirm Order'}
+                  </button>
                 </div>
 
-                <div>
-                  <label
-                    htmlFor="field-sell-price"
-                    className="block text-sm font-medium text-zinc-700 mb-1"
-                  >
-                    Sell price per each ($)
-                  </label>
-                  <input
-                    id="field-sell-price"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    value={form.sellPrice}
-                    onChange={(e) => handleChange('sellPrice', e.target.value)}
-                    placeholder="0.00"
-                    tabIndex={5}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
-                  />
-                  {equivalentRates && (
-                    <p className="mt-1 text-xs text-zinc-500">
-                      {`\u2248 $${equivalentRates.pricePerSqft.toFixed(2)} / sqft \u00b7 $${equivalentRates.pricePerLinft.toFixed(2)} / linft`}
-                    </p>
+                {/* Right column: computed results */}
+                <div className="space-y-4">
+                  {selectedProduct ? (
+                    <>
+                      {/* Product context */}
+                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
+                        <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1">
+                          Product Context
+                        </p>
+                        <p className="text-sm text-zinc-800">
+                          {getProductContextLine(selectedProduct)}
+                        </p>
+                      </div>
+
+                      {/* Unit conversions */}
+                      {computed ? (
+                        <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4 space-y-2">
+                          <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
+                            Unit Conversions
+                          </p>
+                          <div className="flex justify-between text-sm">
+                            <span className="text-zinc-600">Each</span>
+                            <span className="font-medium text-zinc-900">
+                              {formatNumber(computed.qty_eaches)} units
+                            </span>
+                          </div>
+                          <div className="flex justify-between text-sm">
+                            <span className="text-zinc-600">Linear feet</span>
+                            <span className="font-medium text-zinc-900">
+                              {formatNumber(computed.qty_linft)} lin ft
+                            </span>
+                          </div>
+                          <div className="flex justify-between text-sm">
+                            <span className="text-zinc-600">Square feet</span>
+                            <span className="font-medium text-zinc-900">
+                              {formatNumber(computed.qty_sqft)} sq ft
+                            </span>
+                          </div>
+
+                          {isFractionalEaches && (
+                            <div className="mt-2 space-y-2">
+                              <button
+                                type="button"
+                                onClick={handleRoundUp}
+                                className="w-full px-3 py-2 text-xs font-medium text-amber-800 bg-amber-50 border border-amber-300 rounded-md hover:bg-amber-100 transition-colors text-left"
+                              >
+                                {`\u2191 Round up to ${Math.ceil(computed.qty_eaches)} eaches (${Math.ceil(computed.qty_eaches) * ((selectedProduct.properties.width_inches * selectedProduct.properties.length_inches) / 144)} sqft)`}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={handleRoundDown}
+                                className="w-full px-3 py-2 text-xs font-medium text-amber-800 bg-amber-50 border border-amber-300 rounded-md hover:bg-amber-100 transition-colors text-left"
+                              >
+                                {`\u2193 Round down to ${Math.floor(computed.qty_eaches)} eaches (${Math.floor(computed.qty_eaches) * ((selectedProduct.properties.width_inches * selectedProduct.properties.length_inches) / 144)} sqft)`}
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
+                          <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
+                            Unit Conversions
+                          </p>
+                          <p className="text-sm text-zinc-400">
+                            Enter quantity and price to see conversions.
+                          </p>
+                        </div>
+                      )}
+
+                      {/* Cost & Margin */}
+                      {computed ? (
+                        <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4 space-y-2">
+                          <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
+                            Cost & Margin
+                          </p>
+                          <div className="flex justify-between text-sm">
+                            <span className="text-zinc-600">Revenue</span>
+                            <span className="font-medium text-zinc-900">
+                              {formatCurrency(computed.total_revenue)}
+                            </span>
+                          </div>
+                          <div className="flex justify-between text-sm">
+                            <span className="text-zinc-600">Cost</span>
+                            <span className="font-medium text-zinc-900">
+                              {formatCurrency(computed.total_cost)}
+                            </span>
+                          </div>
+
+                          {/* Margin display */}
+                          <div className={`mt-3 rounded-lg border-2 p-4 ${marginClass}`}>
+                            <p className="text-xs font-semibold uppercase tracking-wide opacity-70 mb-1">
+                              Margin
+                            </p>
+                            <div className="flex items-baseline gap-3">
+                              <span className={`text-2xl font-black ${marginTextClass}`}>
+                                {formatCurrency(computed.margin_dollars)}
+                              </span>
+                              <span className={`text-xl font-bold ${marginTextClass}`}>
+                                {formatPercent(computed.margin_percent)}%
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
+                          <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
+                            Cost & Margin
+                          </p>
+                          <p className="text-sm text-zinc-400">
+                            Enter quantity and price to see margin calculation.
+                          </p>
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div className="flex items-center justify-center h-full min-h-48 text-zinc-400 text-sm">
+                      Select a product to see details.
+                    </div>
                   )}
                 </div>
-
-                <div>
-                  <label
-                    htmlFor="field-notes"
-                    className="block text-sm font-medium text-zinc-700 mb-1"
-                  >
-                    Notes (optional)
-                  </label>
-                  <textarea
-                    id="field-notes"
-                    value={form.notes}
-                    onChange={(e) => handleChange('notes', e.target.value)}
-                    placeholder="Notes about this order..."
-                    rows={3}
-                    className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm resize-none"
-                  />
-                </div>
-
-                <button
-                  type="submit"
-                  tabIndex={6}
-                  disabled={submitting || !selectedProduct || !hasQty || !hasPrice}
-                  className="w-full px-4 py-2.5 text-sm font-semibold text-white bg-zinc-800 hover:bg-zinc-900 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {submitting ? 'Submitting...' : 'Confirm Order'}
-                </button>
               </div>
-
-              {/* Right column: computed results */}
-              <div className="space-y-4">
-                {selectedProduct ? (
-                  <>
-                    {/* Product context */}
-                    <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
-                      <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1">
-                        Product Context
-                      </p>
-                      <p className="text-sm text-zinc-800">
-                        {getProductContextLine(selectedProduct)}
-                      </p>
-                    </div>
-
-                    {/* Unit conversions */}
-                    {computed ? (
-                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4 space-y-2">
-                        <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
-                          Unit Conversions
-                        </p>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-zinc-600">Each</span>
-                          <span className="font-medium text-zinc-900">
-                            {formatNumber(computed.qty_eaches)} units
-                          </span>
-                        </div>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-zinc-600">Linear feet</span>
-                          <span className="font-medium text-zinc-900">
-                            {formatNumber(computed.qty_linft)} lin ft
-                          </span>
-                        </div>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-zinc-600">Square feet</span>
-                          <span className="font-medium text-zinc-900">
-                            {formatNumber(computed.qty_sqft)} sq ft
-                          </span>
-                        </div>
-
-                        {isFractionalEaches && (
-                          <div className="mt-2 space-y-2">
-                            <button
-                              type="button"
-                              onClick={handleRoundUp}
-                              className="w-full px-3 py-2 text-xs font-medium text-amber-800 bg-amber-50 border border-amber-300 rounded-md hover:bg-amber-100 transition-colors text-left"
-                            >
-                              {`\u2191 Round up to ${Math.ceil(computed.qty_eaches)} eaches (${Math.ceil(computed.qty_eaches) * ((selectedProduct.properties.width_inches * selectedProduct.properties.length_inches) / 144)} sqft)`}
-                            </button>
-                            <button
-                              type="button"
-                              onClick={handleRoundDown}
-                              className="w-full px-3 py-2 text-xs font-medium text-amber-800 bg-amber-50 border border-amber-300 rounded-md hover:bg-amber-100 transition-colors text-left"
-                            >
-                              {`\u2193 Round down to ${Math.floor(computed.qty_eaches)} eaches (${Math.floor(computed.qty_eaches) * ((selectedProduct.properties.width_inches * selectedProduct.properties.length_inches) / 144)} sqft)`}
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    ) : (
-                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
-                        <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
-                          Unit Conversions
-                        </p>
-                        <p className="text-sm text-zinc-400">
-                          Enter quantity and price to see conversions.
-                        </p>
-                      </div>
-                    )}
-
-                    {/* Cost & Margin */}
-                    {computed ? (
-                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4 space-y-2">
-                        <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
-                          Cost & Margin
-                        </p>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-zinc-600">Revenue</span>
-                          <span className="font-medium text-zinc-900">
-                            {formatCurrency(computed.total_revenue)}
-                          </span>
-                        </div>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-zinc-600">Cost</span>
-                          <span className="font-medium text-zinc-900">
-                            {formatCurrency(computed.total_cost)}
-                          </span>
-                        </div>
-
-                        {/* Margin display */}
-                        <div className={`mt-3 rounded-lg border-2 p-4 ${marginClass}`}>
-                          <p className="text-xs font-semibold uppercase tracking-wide opacity-70 mb-1">
-                            Margin
-                          </p>
-                          <div className="flex items-baseline gap-3">
-                            <span className={`text-2xl font-black ${marginTextClass}`}>
-                              {formatCurrency(computed.margin_dollars)}
-                            </span>
-                            <span className={`text-xl font-bold ${marginTextClass}`}>
-                              {formatPercent(computed.margin_percent)}%
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="bg-zinc-50 rounded-lg border border-zinc-200 p-4">
-                        <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">
-                          Cost & Margin
-                        </p>
-                        <p className="text-sm text-zinc-400">
-                          Enter quantity and price to see margin calculation.
-                        </p>
-                      </div>
-                    )}
-                  </>
-                ) : (
-                  <div className="flex items-center justify-center h-full min-h-48 text-zinc-400 text-sm">
-                    Select a product to see details.
-                  </div>
-                )}
-              </div>
-            </div>
-          </form>
+            </form>
+          )}
         </>
       )}
     </div>

--- a/apps/web/tests/component/order-entry-width-match.test.tsx
+++ b/apps/web/tests/component/order-entry-width-match.test.tsx
@@ -1,0 +1,327 @@
+import { test, expect, describe, beforeEach } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { commands } from '@vitest/browser/context';
+import React from 'react';
+import { OrderEntry } from '../../src/components/OrderEntry';
+import type { Product } from 'core';
+
+// Two products at 48", one at 36"
+const product48a: Product = {
+  id: 'prod-48a',
+  created_at: '2024-01-01T00:00:00Z',
+  properties: {
+    name: '4x4 Welded Wire Mesh',
+    sku: 'WM-48-10FT',
+    material: 'Galvanized Steel',
+    width_inches: 48,
+    length_inches: 120, // 10 ft roll
+    weight_per_sqft: 0.58,
+    cost_per_each: 32.0,
+    cost_per_linft: null,
+    cost_per_sqft: null,
+    primary_cost_basis: 'each',
+    margin_target: 25,
+    margin_floor: 15,
+  },
+};
+
+// Second 48" product — more expensive
+const product48b: Product = {
+  id: 'prod-48b',
+  created_at: '2024-01-02T00:00:00Z',
+  properties: {
+    name: '2x4 Welded Wire Mesh',
+    sku: 'WM-48-5FT',
+    material: 'Galvanized Steel',
+    width_inches: 48,
+    length_inches: 60, // 5 ft roll
+    weight_per_sqft: 0.7,
+    cost_per_each: 20.0,
+    cost_per_linft: null,
+    cost_per_sqft: null,
+    primary_cost_basis: 'each',
+    margin_target: 30,
+    margin_floor: 20,
+  },
+};
+
+const product36: Product = {
+  id: 'prod-36',
+  created_at: '2024-01-03T00:00:00Z',
+  properties: {
+    name: 'Narrow Mesh 36in',
+    sku: 'WM-36-10FT',
+    material: 'Galvanized Steel',
+    width_inches: 36,
+    length_inches: 120,
+    weight_per_sqft: 0.5,
+    cost_per_each: 28.0,
+    cost_per_linft: null,
+    cost_per_sqft: null,
+    primary_cost_basis: 'each',
+    margin_target: 25,
+    margin_floor: 15,
+  },
+};
+
+const ALL_PRODUCTS = [product48a, product48b, product36];
+
+async function switchToByWidth(screen: ReturnType<typeof render>) {
+  // Wait for products to load (mode tabs appear)
+  await expect.element(screen.getByRole('button', { name: 'By Width' })).toBeVisible();
+  await screen.getByRole('button', { name: 'By Width' }).click();
+}
+
+describe('OrderEntry — By Width mode', () => {
+  beforeEach(async () => {
+    await commands.resetFixtureState();
+  });
+
+  test('mode selector shows By Product, By Width, and By Area tabs', async () => {
+    await commands.setFixtureState({ state: { products: ALL_PRODUCTS } });
+
+    const screen = render(<OrderEntry />);
+
+    await expect.element(screen.getByRole('button', { name: 'By Product' })).toBeVisible();
+    await expect.element(screen.getByRole('button', { name: 'By Width' })).toBeVisible();
+    await expect.element(screen.getByRole('button', { name: 'By Area' })).toBeVisible();
+  });
+
+  test('entering width=48 shows only 2 bundles (not the 36" product)', async () => {
+    await commands.setFixtureState({ state: { products: ALL_PRODUCTS } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+
+    // Both 48" products should appear
+    await expect.element(screen.getByText('4x4 Welded Wire Mesh')).toBeVisible();
+    await expect.element(screen.getByText('2x4 Welded Wire Mesh')).toBeVisible();
+
+    // The 36" product must NOT appear
+    await expect.element(screen.getByText('Narrow Mesh 36in')).not.toBeInTheDocument();
+  });
+
+  test('empty state message appears when no products match the width', async () => {
+    await commands.setFixtureState({ state: { products: ALL_PRODUCTS } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    await screen.getByLabelText('Width (inches)').fill('72');
+    await screen.getByLabelText('Total Length (feet)').fill('100');
+
+    await expect.element(screen.getByText(/No products available at 72"/)).toBeVisible();
+  });
+
+  test('each bundle card shows product name, SKU, quantity, and delivered length', async () => {
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    // 200 ft / 10 ft per roll = 20 rolls exactly
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+
+    await expect.element(screen.getByText('4x4 Welded Wire Mesh')).toBeVisible();
+    await expect.element(screen.getByText('WM-48-10FT')).toBeVisible();
+    await expect.element(screen.getByText(/20.*rolls/)).toBeVisible();
+    // 20 rolls * 10 ft = 200 ft
+    await expect.element(screen.getByText(/200.*ft/)).toBeVisible();
+    await expect.element(screen.getByText(/no waste/)).toBeVisible();
+  });
+
+  test('bundle with overage shows overage line feet correctly', async () => {
+    await commands.setFixtureState({ state: { products: [product48b] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    // product48b: 5 ft rolls. 200 ft / 5 ft = 40 rolls exactly, no overage
+    // Use 201 ft: ceil(201/5) = 41 rolls → delivered = 205 ft → overage = 5 ft
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('201');
+
+    await expect.element(screen.getByText(/5.*ft overage|5 ft overage/)).toBeVisible();
+  });
+
+  test('entering sell price shows price/sqft and price/linft on bundle card', async () => {
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    // 200 ft / 10 ft per roll = 20 rolls. Sell price $50/each.
+    // total revenue = 20 * 50 = 1000
+    // totalLinft = 200, totalSqft = 200 * 4 = 800 (48" = 4 ft wide)
+    // price/sqft = 1000 / 800 = 1.25
+    // price/linft = 1000 / 200 = 5.00
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+    await screen.getByLabelText('Sell price per unit ($)').fill('50');
+
+    await expect.element(screen.getByText(/\$1\.25/)).toBeVisible();
+    await expect.element(screen.getByText(/\/ sqft/)).toBeVisible();
+    await expect.element(screen.getByText(/\$5\.00/)).toBeVisible();
+    await expect.element(screen.getByText(/\/ linft/)).toBeVisible();
+  });
+
+  test('margin is shown with correct color for healthy margin', async () => {
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    // product48a: cost_per_each=32, margin_target=25, margin_floor=15
+    // 200 ft / 10 ft = 20 rolls, cost = 20 * 32 = 640
+    // sell price $50/each → revenue = 20 * 50 = 1000
+    // margin = (1000 - 640) / 1000 = 36% → healthy (>= 25% target)
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+    await screen.getByLabelText('Sell price per unit ($)').fill('50');
+
+    const marginEl = screen.getByText(/36\.0%/);
+    await expect.element(marginEl).toBeVisible();
+    expect(marginEl.element().closest('.bg-emerald-50')).not.toBeNull();
+  });
+
+  test('margin is shown with correct color for warning margin', async () => {
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    // product48a: cost_per_each=32, margin_target=25, margin_floor=15
+    // 20 rolls, cost = 640; sell $38/each → revenue = 760
+    // margin = (760 - 640) / 760 = 120/760 ≈ 15.8% → warning (between 15 floor and 25 target)
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+    await screen.getByLabelText('Sell price per unit ($)').fill('38');
+
+    const marginEl = screen.getByText(/15\.8%/);
+    await expect.element(marginEl).toBeVisible();
+    expect(marginEl.element().closest('.bg-amber-50')).not.toBeNull();
+  });
+
+  test('margin is shown with correct color for critical margin', async () => {
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    // product48a: cost_per_each=32, margin_target=25, margin_floor=15
+    // 20 rolls, cost = 640; sell $36/each → revenue = 720
+    // margin = (720 - 640) / 720 = 80/720 ≈ 11.1% → critical (below 15 floor)
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+    await screen.getByLabelText('Sell price per unit ($)').fill('36');
+
+    const marginEl = screen.getByText(/11\.1%/);
+    await expect.element(marginEl).toBeVisible();
+    expect(marginEl.element().closest('.bg-red-50')).not.toBeNull();
+  });
+
+  test('sort by Price/sqft changes bundle order', async () => {
+    await commands.setFixtureState({ state: { products: ALL_PRODUCTS } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+    await screen.getByLabelText('Sell price per unit ($)').fill('50');
+
+    // Click sort by sqft
+    await screen.getByRole('button', { name: /Price\/sqft/ }).click();
+
+    // Both 48" bundles are visible
+    await expect.element(screen.getByText('4x4 Welded Wire Mesh')).toBeVisible();
+    await expect.element(screen.getByText('2x4 Welded Wire Mesh')).toBeVisible();
+  });
+
+  test('sort by Price/linft changes bundle order', async () => {
+    await commands.setFixtureState({ state: { products: ALL_PRODUCTS } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+    await screen.getByLabelText('Sell price per unit ($)').fill('50');
+
+    // Click sort by linft
+    await screen.getByRole('button', { name: /Price\/linft/ }).click();
+
+    await expect.element(screen.getByText('4x4 Welded Wire Mesh')).toBeVisible();
+    await expect.element(screen.getByText('2x4 Welded Wire Mesh')).toBeVisible();
+  });
+
+  test('clicking Select for Quote populates order form with correct product and quantity', async () => {
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    // 200 ft / 10 ft per roll = 20 rolls
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+    await screen.getByLabelText('Sell price per unit ($)').fill('50');
+
+    await screen.getByRole('button', { name: 'Select for Quote' }).click();
+
+    // Should return to By Product mode
+    await expect.element(screen.getByLabelText('Product')).toBeVisible();
+
+    // Product should be pre-selected
+    const productSelect = screen.getByLabelText('Product');
+    await expect.element(productSelect).toHaveValue('prod-48a');
+
+    // Quantity should be 20 (eaches)
+    await expect.element(screen.getByLabelText('Quantity')).toHaveValue(20);
+
+    // Sell price should be pre-filled with 50
+    await expect.element(screen.getByLabelText('Sell price per each ($)')).toHaveValue(50);
+  });
+
+  test('clicking Select for Quote switches back to By Product mode', async () => {
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+
+    await screen.getByRole('button', { name: 'Select for Quote' }).click();
+
+    // By Product form fields should be visible
+    await expect.element(screen.getByLabelText('Customer')).toBeVisible();
+    await expect.element(screen.getByLabelText('Product')).toBeVisible();
+    await expect.element(screen.getByLabelText('Quantity')).toBeVisible();
+
+    // Width fields should no longer be visible
+    await expect.element(screen.getByLabelText('Width (inches)')).not.toBeInTheDocument();
+  });
+
+  test('sell price updates margin on all visible bundle cards', async () => {
+    await commands.setFixtureState({ state: { products: [product48a, product48b] } });
+
+    const screen = render(<OrderEntry />);
+    await switchToByWidth(screen);
+
+    await screen.getByLabelText('Width (inches)').fill('48');
+    await screen.getByLabelText('Total Length (feet)').fill('200');
+
+    // Enter a sell price — both cards should show margin
+    await screen.getByLabelText('Sell price per unit ($)').fill('50');
+
+    // Both cards should display margin percentages
+    // product48a: 20 rolls * $32 cost = $640 cost; 20 * $50 = $1000 rev → 36% margin
+    // product48b: 40 rolls (200ft/5ft) * $20 cost = $800 cost; 40 * $50 = $2000 rev → 60% margin
+    await expect.element(screen.getByText('36.0%')).toBeVisible();
+    await expect.element(screen.getByText('60.0%')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Implements #32.

Adds a mode selector ("By Product" | "By Width" | "By Area") to the order entry view. The "By Width" mode lets reps enter a customer's width requirement and total length, then instantly see bundle options with pricing and margin.

**New in `OrderEntry.tsx`:**
- Tab-style mode selector at top of order entry
- `ByWidthPanel`: width + length + sell price inputs, client-side bundle computation via `findBundlesByWidth` from `packages/core`
- `BundleCard`: product name, SKU, quantity, delivered linft, overage, price/sqft, price/linft, margin with color coding
- Sort controls (price/sqft, price/linft)
- Empty state when no products match the width
- "Select for Quote" pre-fills the By Product form and switches mode
- "By Area" tab present as placeholder for issue #33

**New test file:** `order-entry-width-match.test.tsx` — 14 component tests covering all acceptance criteria.

All 128 tests pass.

## Test plan

See #32 for acceptance criteria and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)