### PR TITLE
fix: margin color mismatch when target-seeded price rounds below threshold

### DIFF
--- a/apps/web/src/components/OrderEntry.tsx
+++ b/apps/web/src/components/OrderEntry.tsx
@@ -26,10 +26,11 @@ const MODE_TABS: { value: OrderMode; label: string }[] = [
   { value: 'search-by-uom', label: 'Search by UoM' },
 ];
 
-function targetMarginPricePerEach(product: Product): string {
+export function targetMarginPricePerEach(product: Product): string {
   const costPerEach = product.properties.cost_per_each ?? 0;
   const target = product.properties.margin_target / 100;
-  return (costPerEach / (1 - target)).toFixed(2);
+  const raw = costPerEach / (1 - target);
+  return (Math.ceil(raw * 100) / 100).toFixed(2);
 }
 
 interface OrderForm {

--- a/apps/web/src/components/order-entry/MarginBox.tsx
+++ b/apps/web/src/components/order-entry/MarginBox.tsx
@@ -40,7 +40,8 @@ export function MarginBox({
   marginFloor,
   variant = 'compact',
 }: MarginBoxProps) {
-  const health = evaluateMargin(marginPercent, marginTarget, marginFloor);
+  const displayMargin = Math.round(marginPercent * 10) / 10;
+  const health = evaluateMargin(displayMargin, marginTarget, marginFloor);
   const colorClass = MARGIN_COLOR_CLASSES[health];
   const textClass = MARGIN_TEXT_CLASSES[health];
 

--- a/apps/web/tests/component/order-entry.test.tsx
+++ b/apps/web/tests/component/order-entry.test.tsx
@@ -303,6 +303,45 @@ describe('OrderEntry — Specific Product mode', () => {
       .toHaveAttribute('tabindex', '6');
   });
 
+  test('margin box is green (emerald) when auto-seeded sell price is selected at target margin', async () => {
+    await commands.setFixtureState({ state: { products: [fixtureProduct] } });
+
+    const screen = render(<OrderEntry />);
+
+    await waitAndSelectProduct(screen);
+    // Use the auto-seeded price (target-margin rate) and enter a quantity
+    // The seeded price must yield >= 25% margin so the margin box should be green
+    await screen.getByLabelText('Quantity').fill('200');
+    // The sell price input should already be seeded with the target-margin price
+
+    // Confirm the margin percent displayed rounds to 25.0% or above
+    const marginPercentEl = screen.getByText(/25\.0%|2[6-9]\.\d%|[3-9]\d\.\d%/);
+    await expect.element(marginPercentEl).toBeVisible();
+    const el = marginPercentEl.element();
+    expect(el.closest('.bg-emerald-50')).not.toBeNull();
+  });
+
+  test('margin box is green when displayed margin rounds to target (Fix 2: display-aligned color)', async () => {
+    // This test verifies that when margin_percent rounds to exactly the target (e.g. 25.0%),
+    // the margin box is green (emerald), not amber — fixing the display/color mismatch.
+    await commands.setFixtureState({ state: { products: [fixtureProduct] } });
+
+    const screen = render(<OrderEntry />);
+
+    await waitAndSelectProduct(screen);
+    // 200 sqft = 5 eaches at $42.67/each:
+    // Revenue = 5 * 42.67 = 213.35, Cost = 5 * 32 = 160
+    // Margin = 53.35 / 213.35 = 24.9941...% — displays as "25.0%" but raw is below 25%
+    // Fix 2 ensures evaluateMargin uses the rounded display value → healthy/green
+    await screen.getByLabelText('Quantity').fill('200');
+    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+
+    const marginSection = screen.getByText('25.0%');
+    await expect.element(marginSection).toBeVisible();
+    const marginEl = marginSection.element();
+    expect(marginEl.closest('.bg-emerald-50')).not.toBeNull();
+  });
+
   test('mode selector shows exactly two tabs: "Specific Product" and "Search by UoM"', async () => {
     await commands.setFixtureState({ state: { products: [fixtureProduct] } });
 

--- a/apps/web/tests/unit/target-margin-price.test.ts
+++ b/apps/web/tests/unit/target-margin-price.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { targetMarginPricePerEach } from '../../src/components/OrderEntry';
+import { calculateMargin } from 'core';
+import type { Product } from 'core';
+
+const makeProduct = (cost_per_each: number, margin_target: number): Product => ({
+  id: 'prod-test',
+  created_at: '2024-01-01T00:00:00Z',
+  properties: {
+    name: 'Test Product',
+    sku: 'TEST-001',
+    material: 'Steel',
+    width_inches: 48,
+    length_inches: 120,
+    weight_per_sqft: 0.58,
+    cost_per_each,
+    cost_per_linft: null,
+    cost_per_sqft: null,
+    primary_cost_basis: 'each',
+    margin_target,
+    margin_floor: 15,
+  },
+});
+
+describe('targetMarginPricePerEach', () => {
+  it('returns a price yielding margin >= target for cost=$32, target=25%', () => {
+    const product = makeProduct(32, 25);
+    const priceStr = targetMarginPricePerEach(product);
+    const price = parseFloat(priceStr);
+
+    // Price must be a 2-decimal string
+    expect(priceStr).toMatch(/^\d+\.\d{2}$/);
+
+    // Margin at this price must be >= 25%
+    const { percent } = calculateMargin(price, 32);
+    expect(percent).toBeGreaterThanOrEqual(25);
+  });
+
+  it('returns a price yielding margin >= target for cost=$19.20, target=25%', () => {
+    const product = makeProduct(19.2, 25);
+    const priceStr = targetMarginPricePerEach(product);
+    const price = parseFloat(priceStr);
+
+    expect(priceStr).toMatch(/^\d+\.\d{2}$/);
+
+    const { percent } = calculateMargin(price, 19.2);
+    expect(percent).toBeGreaterThanOrEqual(25);
+  });
+
+  it('uses ceiling so displayed price never rounds below target margin', () => {
+    // cost=$19.21, target=25%: raw = 19.21/0.75 = 25.6133...
+    // floor(toFixed(2)) would give 25.61 → margin = (25.61-19.21)/25.61*100 < 25%
+    // ceiling must give 25.62 → margin >= 25%
+    const product = makeProduct(19.21, 25);
+    const priceStr = targetMarginPricePerEach(product);
+    const price = parseFloat(priceStr);
+
+    const { percent } = calculateMargin(price, 19.21);
+    expect(percent).toBeGreaterThanOrEqual(25);
+  });
+
+  it('guarantee holds across a range of costs with target=25%', () => {
+    // Test multiple costs that might trigger rounding edge cases
+    const testCosts = [1.0, 5.0, 10.0, 19.2, 19.21, 32.0, 47.33, 100.0];
+    for (const cost of testCosts) {
+      const product = makeProduct(cost, 25);
+      const priceStr = targetMarginPricePerEach(product);
+      const price = parseFloat(priceStr);
+      const { percent } = calculateMargin(price, cost);
+      expect(percent).toBeGreaterThanOrEqual(25);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements #48. Closes #48.

## Status

🚧 Work in progress

## Test plan

See #48 for acceptance criteria and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)