### PR TITLE
fix: order entry UX polish — customer state, overage display, pill tooltips, labels

### DIFF
--- a/apps/web/src/components/OrderEntry.tsx
+++ b/apps/web/src/components/OrderEntry.tsx
@@ -34,7 +34,6 @@ export function targetMarginPricePerEach(product: Product): string {
 }
 
 interface OrderForm {
-  customer: string;
   productId: string;
   quantity: string;
   uom: UnitOfMeasure;
@@ -43,7 +42,6 @@ interface OrderForm {
 }
 
 const EMPTY_FORM: OrderForm = {
-  customer: '',
   productId: '',
   quantity: '',
   uom: 'square_foot',
@@ -73,15 +71,21 @@ function formatNumber(value: number, decimals = 2): string {
 
 interface SearchByUoMPanelProps {
   products: Product[];
+  customer: string;
+  onCustomerChange: (v: string) => void;
   onNavigateToHistory?: () => void;
 }
 
-function SearchByUoMPanel({ products, onNavigateToHistory }: SearchByUoMPanelProps) {
+function SearchByUoMPanel({
+  products,
+  customer,
+  onCustomerChange,
+  onNavigateToHistory,
+}: SearchByUoMPanelProps) {
   const [toggle, setToggle] = useState<SearchUomToggle>('linft');
   const [width, setWidth] = useState('');
   const [length, setLength] = useState('');
   const [sqft, setSqft] = useState('');
-  const [customer, setCustomer] = useState('');
   const [sortKey, setSortKey] = useState<BundleSortKey>('price-sqft');
   const [creating, setCreating] = useState(false);
 
@@ -185,7 +189,7 @@ function SearchByUoMPanel({ products, onNavigateToHistory }: SearchByUoMPanelPro
           id="search-customer"
           type="text"
           value={customer}
-          onChange={(e) => setCustomer(e.target.value)}
+          onChange={(e) => onCustomerChange(e.target.value)}
           placeholder="Customer name"
           className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
         />
@@ -213,7 +217,7 @@ function SearchByUoMPanel({ products, onNavigateToHistory }: SearchByUoMPanelPro
               : 'text-zinc-600 hover:text-zinc-900'
           }`}
         >
-          Sqft
+          Sq ft
         </button>
       </div>
 
@@ -329,6 +333,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({ onNavigateToHistory }) =
   const [productError, setProductError] = useState<string | null>(null);
 
   const [mode, setMode] = useState<OrderMode>('specific-product');
+  const [customer, setCustomer] = useState('');
 
   // Tracks whether the current product selection came from "Select for Quote".
   // When true, skip the auto-seed of sell price so the quoted price is preserved.
@@ -460,7 +465,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({ onNavigateToHistory }) =
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
-          customer: form.customer.trim(),
+          customer: customer.trim(),
           product_id: form.productId,
           quantity: qty,
           unit_of_measure: form.uom,
@@ -476,6 +481,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({ onNavigateToHistory }) =
       }
 
       setSuccessMessage('Order confirmed successfully!');
+      setCustomer('');
       setForm({ ...EMPTY_FORM });
     } catch {
       setSubmitError('Network error submitting order');
@@ -542,7 +548,12 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({ onNavigateToHistory }) =
           </div>
 
           {mode === 'search-by-uom' && (
-            <SearchByUoMPanel products={products} onNavigateToHistory={onNavigateToHistory} />
+            <SearchByUoMPanel
+              products={products}
+              customer={customer}
+              onCustomerChange={setCustomer}
+              onNavigateToHistory={onNavigateToHistory}
+            />
           )}
 
           {mode === 'specific-product' && (
@@ -560,8 +571,8 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({ onNavigateToHistory }) =
                     <input
                       id="field-customer"
                       type="text"
-                      value={form.customer}
-                      onChange={(e) => handleChange('customer', e.target.value)}
+                      value={customer}
+                      onChange={(e) => setCustomer(e.target.value)}
                       placeholder="Customer name"
                       tabIndex={1}
                       className="w-full px-3 py-2 border border-zinc-300 rounded-md focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 outline-none text-sm"
@@ -639,7 +650,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({ onNavigateToHistory }) =
                       htmlFor="field-sell-price"
                       className="block text-sm font-medium text-zinc-700 mb-1"
                     >
-                      Sell price per each ($)
+                      Sell price per roll ($)
                     </label>
                     <input
                       id="field-sell-price"

--- a/apps/web/src/components/order-entry/BundleCardBase.tsx
+++ b/apps/web/src/components/order-entry/BundleCardBase.tsx
@@ -133,7 +133,13 @@ export function BundleCardBase({
               ? overage / (items[0].product.properties.width_inches / 12)
               : overage;
           const rounded = Math.round(overageLinft * 10) / 10;
-          return rounded <= 0 ? 'no waste' : `${formatNumber(rounded, 1)} ft overage`;
+          const totalDeliveredFt = items.reduce(
+            (sum, item) => sum + item.quantity * (item.product.properties.length_inches / 12),
+            0,
+          );
+          return rounded <= 0
+            ? `${totalDeliveredFt} ft delivered — no waste`
+            : `${totalDeliveredFt} ft delivered — ${formatNumber(rounded, 1)} ft overage`;
         })()
       : (() => {
           const rounded = Math.round(overage * 10) / 10;
@@ -158,6 +164,11 @@ export function BundleCardBase({
             </span>
           )}
         </div>
+      )}
+      {(isBestMargin || isLeastWaste) && (
+        <p className="text-xs text-zinc-400">
+          Best Margin = lowest cost bundle · Least Waste = least overage
+        </p>
       )}
 
       {/* Item rows */}

--- a/apps/web/tests/component/order-entry-ux-polish.test.tsx
+++ b/apps/web/tests/component/order-entry-ux-polish.test.tsx
@@ -1,0 +1,140 @@
+import { test, expect, describe, beforeEach } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { commands } from '@vitest/browser/context';
+import { page } from '@vitest/browser/context';
+import React from 'react';
+import { OrderEntry } from '../../src/components/OrderEntry';
+import { BundleCardBase } from '../../src/components/order-entry/BundleCardBase';
+import type { Product, Bundle } from 'core';
+
+const fixtureProduct: Product = {
+  id: 'prod-1',
+  created_at: '2024-01-01T00:00:00Z',
+  properties: {
+    name: '4x4 Welded Wire Mesh',
+    sku: 'WM-4X4-10GA',
+    material: 'Galvanized Steel',
+    width_inches: 48,
+    length_inches: 120,
+    weight_per_sqft: 0.58,
+    cost_per_each: 32.0,
+    cost_per_linft: null,
+    cost_per_sqft: null,
+    primary_cost_basis: 'each',
+    margin_target: 25,
+    margin_floor: 15,
+  },
+};
+
+// length_inches=120 => 10 ft per roll
+// 3 rolls => totalDeliveredFt = 30 ft
+const makeLinftBundle = (quantity: number, overage: number): Bundle => ({
+  items: [{ product: fixtureProduct, quantity }],
+  totalSqft: quantity * 40,
+  totalLinft: quantity * 10,
+  overage,
+  overageUnit: 'linft',
+  costTotal: quantity * 32,
+  pricePerSqft: 32 / 40,
+  pricePerLinft: 32 / 10,
+});
+
+describe('OrderEntry UX polish — shared customer state', () => {
+  beforeEach(async () => {
+    await commands.resetFixtureState();
+  });
+
+  test('customer typed in Specific Product mode persists when switching to Search by UoM', async () => {
+    await commands.setFixtureState({ state: { products: [fixtureProduct] } });
+
+    render(<OrderEntry />);
+
+    // Type customer name in Specific Product mode (default mode)
+    await page.getByLabel('Customer').fill('Acme Fencing Co');
+
+    // Switch to Search by UoM tab
+    await page.getByRole('button', { name: 'Search by UoM' }).click();
+
+    // Customer field in Search by UoM panel should retain the value
+    await expect.element(page.getByLabel('Customer')).toHaveValue('Acme Fencing Co');
+  });
+});
+
+describe('OrderEntry UX polish — linft overage display', () => {
+  test('linft bundle card with no overage shows "X ft delivered — no waste"', async () => {
+    // 3 rolls × 10 ft = 30 ft delivered, overage=0
+    const bundle = makeLinftBundle(3, 0);
+
+    render(
+      <BundleCardBase
+        bundle={bundle}
+        bundleKey="test-no-overage"
+        displayMode="linft"
+        customer=""
+        onCreateOrders={() => {}}
+      />,
+    );
+
+    await expect.element(page.getByText('30 ft delivered — no waste')).toBeVisible();
+  });
+
+  test('linft bundle card with overage shows "X ft delivered — Y ft overage"', async () => {
+    // 3 rolls × 10 ft = 30 ft delivered
+    // overage = 5 sqft; width=48" => overageLinft = 5 / (48/12) = 5 / 4 = 1.25 ft
+    const bundle = makeLinftBundle(3, 5);
+
+    render(
+      <BundleCardBase
+        bundle={bundle}
+        bundleKey="test-with-overage"
+        displayMode="linft"
+        customer=""
+        onCreateOrders={() => {}}
+      />,
+    );
+
+    await expect.element(page.getByText(/30 ft delivered — 1\.3 ft overage/)).toBeVisible();
+  });
+});
+
+describe('OrderEntry UX polish — pill badge explanatory text', () => {
+  test('explanatory text appears when at least one pill badge is shown', async () => {
+    const bundle = makeLinftBundle(5, 0);
+
+    render(
+      <BundleCardBase
+        bundle={bundle}
+        bundleKey="test-pill-text"
+        displayMode="linft"
+        customer=""
+        onCreateOrders={() => {}}
+        isBestMargin={true}
+        isLeastWaste={false}
+      />,
+    );
+
+    await expect
+      .element(page.getByText('Best Margin = lowest cost bundle · Least Waste = least overage'))
+      .toBeVisible();
+  });
+
+  test('explanatory text does not appear when no pill badges are shown', async () => {
+    const bundle = makeLinftBundle(5, 0);
+
+    render(
+      <BundleCardBase
+        bundle={bundle}
+        bundleKey="test-no-pill-text"
+        displayMode="linft"
+        customer=""
+        onCreateOrders={() => {}}
+        isBestMargin={false}
+        isLeastWaste={false}
+      />,
+    );
+
+    await expect
+      .element(page.getByText('Best Margin = lowest cost bundle · Least Waste = least overage'))
+      .not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/component/order-entry.test.tsx
+++ b/apps/web/tests/component/order-entry.test.tsx
@@ -60,14 +60,14 @@ describe('OrderEntry — Specific Product mode', () => {
     await expect.element(screen.getByText(/Galvanized Steel/)).toBeVisible();
   });
 
-  test('sell price label reads "Sell price per each ($)"', async () => {
+  test('sell price label reads "Sell price per roll ($)"', async () => {
     await commands.setFixtureState({ state: { products: [fixtureProduct] } });
 
     const screen = render(<OrderEntry />);
 
     await waitAndSelectProduct(screen);
 
-    await expect.element(screen.getByLabelText('Sell price per each ($)')).toBeVisible();
+    await expect.element(screen.getByLabelText('Sell price per roll ($)')).toBeVisible();
   });
 
   test('default sell price on product selection is target-margin per-each rate', async () => {
@@ -78,7 +78,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
 
     // 32 / (1 - 0.25) = 42.666... => "42.67"
-    await expect.element(screen.getByLabelText('Sell price per each ($)')).toHaveValue(42.67);
+    await expect.element(screen.getByLabelText('Sell price per roll ($)')).toHaveValue(42.67);
   });
 
   test('entering quantity and UOM shows converted quantities in all three units', async () => {
@@ -89,7 +89,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // Default UOM is square_foot; 200 sqft = 5 eaches = 50 linear feet
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByText(/5.*units/)).toBeVisible();
     await expect.element(screen.getByText(/50.*lin ft/)).toBeVisible();
@@ -104,7 +104,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // With $42.67/each, sqftPerEach=40, linftPerEach=10:
     // pricePerSqft = 42.67 / 40 = 1.07, pricePerLinft = 42.67 / 10 = 4.27
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByText(/\$1\.07 \/ sqft/)).toBeVisible();
     await expect.element(screen.getByText(/\$4\.27 \/ linft/)).toBeVisible();
@@ -119,7 +119,7 @@ describe('OrderEntry — Specific Product mode', () => {
     // 200 sqft = 5 eaches; $42.67/each => revenue = 5 * 42.67 = 213.35
     // cost = 5 * 32 = 160; margin = (213.35 - 160) / 213.35 = 25%
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByText(/213\.35/)).toBeVisible();
     await expect.element(screen.getByText(/160/)).toBeVisible();
@@ -133,7 +133,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $50/each: Revenue = 250, Cost = 5 × 32 = 160, Margin = 90/250 = 36%
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('50');
+    await screen.getByLabelText('Sell price per roll ($)').fill('50');
 
     await expect.element(screen.getByText(/250/)).toBeVisible();
     await expect.element(screen.getByText(/160/)).toBeVisible();
@@ -148,7 +148,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $50/each → 36% margin — above 25% target → healthy/green
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('50');
+    await screen.getByLabelText('Sell price per roll ($)').fill('50');
 
     const marginSection = screen.getByText('36.0%');
     await expect.element(marginSection).toBeVisible();
@@ -164,7 +164,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $38/each: Revenue = 190, Cost = 160, Margin = 30/190 = 15.8% — between 15% floor and 25% target
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('38');
+    await screen.getByLabelText('Sell price per roll ($)').fill('38');
 
     const marginSection = screen.getByText('15.8%');
     await expect.element(marginSection).toBeVisible();
@@ -180,7 +180,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $36/each: Revenue = 180, Cost = 160, Margin = 20/180 = 11.1% — below 15% floor
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('36');
+    await screen.getByLabelText('Sell price per roll ($)').fill('36');
 
     const marginSection = screen.getByText('11.1%');
     await expect.element(marginSection).toBeVisible();
@@ -196,7 +196,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 100 sqft / 40 sqft per each = 2.5 eaches (fractional)
     await screen.getByLabelText('Quantity').fill('100');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     // ceil(2.5) = 3, 3 * 40 = 120 sqft; floor(2.5) = 2, 2 * 40 = 80 sqft
     await expect
@@ -214,7 +214,7 @@ describe('OrderEntry — Specific Product mode', () => {
 
     await waitAndSelectProduct(screen);
     await screen.getByLabelText('Quantity').fill('100');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await screen.getByRole('button', { name: /Round up to 3 eaches \(120 sqft\)/ }).click();
 
@@ -234,7 +234,7 @@ describe('OrderEntry — Specific Product mode', () => {
 
     await waitAndSelectProduct(screen);
     await screen.getByLabelText('Quantity').fill('100');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await screen.getByRole('button', { name: /Round down to 2 eaches \(80 sqft\)/ }).click();
 
@@ -255,7 +255,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches (integer) — no rounding buttons
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByRole('button', { name: /Round up/ })).not.toBeInTheDocument();
     await expect
@@ -271,7 +271,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await screen.getByLabelText('Customer').fill('Acme Fencing Co');
     await waitAndSelectProduct(screen);
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('50');
+    await screen.getByLabelText('Sell price per roll ($)').fill('50');
 
     await screen.getByRole('button', { name: 'Confirm Order' }).click();
 
@@ -296,7 +296,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await expect.element(screen.getByLabelText('Quantity')).toHaveAttribute('tabindex', '3');
     await expect.element(screen.getByLabelText('Unit of measure')).toHaveAttribute('tabindex', '4');
     await expect
-      .element(screen.getByLabelText('Sell price per each ($)'))
+      .element(screen.getByLabelText('Sell price per roll ($)'))
       .toHaveAttribute('tabindex', '5');
     await expect
       .element(screen.getByRole('button', { name: 'Confirm Order' }))
@@ -334,7 +334,7 @@ describe('OrderEntry — Specific Product mode', () => {
     // Margin = 53.35 / 213.35 = 24.9941...% — displays as "25.0%" but raw is below 25%
     // Fix 2 ensures evaluateMargin uses the rounded display value → healthy/green
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     const marginSection = screen.getByText('25.0%');
     await expect.element(marginSection).toBeVisible();


### PR DESCRIPTION
Implements #56. Closes #56. 🚧 Work in progress. See #56 for acceptance criteria.