### PR TITLE
fix: order entry UX polish — overage display, pill tooltips, labels

### DIFF
--- a/apps/web/src/components/OrderEntry.tsx
+++ b/apps/web/src/components/OrderEntry.tsx
@@ -292,7 +292,7 @@ function SearchByUoMPanel({
               : 'text-zinc-600 hover:text-zinc-900'
           }`}
         >
-          Sqft
+          Sq ft
         </button>
       </div>
 
@@ -781,7 +781,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({ onNavigateToHistory }) =
                       htmlFor="field-sell-price"
                       className="block text-sm font-medium text-zinc-700 mb-1"
                     >
-                      Sell price per each ($)
+                      Sell price per roll ($)
                     </label>
                     <input
                       id="field-sell-price"

--- a/apps/web/src/components/order-entry/BundleCardBase.tsx
+++ b/apps/web/src/components/order-entry/BundleCardBase.tsx
@@ -164,13 +164,11 @@ export function BundleCardBase({
   const overageDisplay =
     displayMode === 'linft'
       ? (() => {
-          // Convert sqft overage to linft if needed
-          const overageLinft =
-            items.length === 1
-              ? overage / (items[0].product.properties.width_inches / 12)
-              : overage;
-          const rounded = Math.round(overageLinft * 10) / 10;
-          return rounded <= 0 ? 'no waste' : `${formatNumber(rounded, 1)} ft overage`;
+          // overage is already in linft for linft-mode bundles
+          const rounded = Math.round(overage * 10) / 10;
+          return rounded <= 0
+            ? `${formatNumber(totalLinft, 0)} ft delivered — no waste`
+            : `${formatNumber(totalLinft, 0)} ft delivered — ${formatNumber(rounded, 1)} ft overage`;
         })()
       : (() => {
           const rounded = Math.round(overage * 10) / 10;
@@ -183,17 +181,22 @@ export function BundleCardBase({
     <div className="bg-white border border-zinc-200 rounded-lg p-4 space-y-3">
       {/* Pill badges */}
       {(isBestMargin || isLeastWaste) && (
-        <div className="flex gap-1.5">
-          {isBestMargin && (
-            <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-700">
-              Best Margin
-            </span>
-          )}
-          {isLeastWaste && (
-            <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-indigo-100 text-indigo-700">
-              Least Waste
-            </span>
-          )}
+        <div className="space-y-1">
+          <div className="flex gap-1.5">
+            {isBestMargin && (
+              <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-700">
+                Best Margin
+              </span>
+            )}
+            {isLeastWaste && (
+              <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-indigo-100 text-indigo-700">
+                Least Waste
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-zinc-400">
+            Best Margin = lowest cost bundle &middot; Least Waste = least overage
+          </p>
         </div>
       )}
 

--- a/apps/web/tests/component/bundle-pill-badges.test.tsx
+++ b/apps/web/tests/component/bundle-pill-badges.test.tsx
@@ -68,10 +68,10 @@ describe('BundleCardBase pill badges', () => {
       />,
     );
 
-    await expect.element(page.getByText('Best Margin')).toBeVisible();
-    await expect.element(page.getByText('Least Waste')).not.toBeInTheDocument();
+    await expect.element(page.getByText('Best Margin', { exact: true })).toBeVisible();
+    await expect.element(page.getByText('Least Waste', { exact: true })).not.toBeInTheDocument();
 
-    const pill = page.getByText('Best Margin').element();
+    const pill = page.getByText('Best Margin', { exact: true }).element();
     expect(pill.classList.contains('bg-emerald-100')).toBe(true);
     expect(pill.classList.contains('text-emerald-700')).toBe(true);
   });
@@ -89,10 +89,10 @@ describe('BundleCardBase pill badges', () => {
       />,
     );
 
-    await expect.element(page.getByText('Least Waste')).toBeVisible();
-    await expect.element(page.getByText('Best Margin')).not.toBeInTheDocument();
+    await expect.element(page.getByText('Least Waste', { exact: true })).toBeVisible();
+    await expect.element(page.getByText('Best Margin', { exact: true })).not.toBeInTheDocument();
 
-    const pill = page.getByText('Least Waste').element();
+    const pill = page.getByText('Least Waste', { exact: true }).element();
     expect(pill.classList.contains('bg-indigo-100')).toBe(true);
     expect(pill.classList.contains('text-indigo-700')).toBe(true);
   });
@@ -110,8 +110,8 @@ describe('BundleCardBase pill badges', () => {
       />,
     );
 
-    await expect.element(page.getByText('Best Margin')).toBeVisible();
-    await expect.element(page.getByText('Least Waste')).toBeVisible();
+    await expect.element(page.getByText('Best Margin', { exact: true })).toBeVisible();
+    await expect.element(page.getByText('Least Waste', { exact: true })).toBeVisible();
   });
 
   test('neither pill prop set: no pills rendered', async () => {
@@ -125,8 +125,8 @@ describe('BundleCardBase pill badges', () => {
       />,
     );
 
-    await expect.element(page.getByText('Best Margin')).not.toBeInTheDocument();
-    await expect.element(page.getByText('Least Waste')).not.toBeInTheDocument();
+    await expect.element(page.getByText('Best Margin', { exact: true })).not.toBeInTheDocument();
+    await expect.element(page.getByText('Least Waste', { exact: true })).not.toBeInTheDocument();
   });
 
   test('3 cards: only bundle with lowest costTotal gets Best Margin, only lowest overage gets Least Waste', async () => {
@@ -166,11 +166,11 @@ describe('BundleCardBase pill badges', () => {
     );
 
     // Exactly 1 Best Margin pill (bundleB)
-    const bestMarginPills = await page.getByText('Best Margin').all();
+    const bestMarginPills = await page.getByText('Best Margin', { exact: true }).all();
     expect(bestMarginPills).toHaveLength(1);
 
     // Exactly 1 Least Waste pill (bundleA)
-    const leastWastePills = await page.getByText('Least Waste').all();
+    const leastWastePills = await page.getByText('Least Waste', { exact: true }).all();
     expect(leastWastePills).toHaveLength(1);
   });
 
@@ -203,8 +203,8 @@ describe('BundleCardBase pill badges', () => {
       </div>,
     );
 
-    const bestMarginPills = await page.getByText('Best Margin').all();
-    const leastWastePills = await page.getByText('Least Waste').all();
+    const bestMarginPills = await page.getByText('Best Margin', { exact: true }).all();
+    const leastWastePills = await page.getByText('Least Waste', { exact: true }).all();
 
     expect(bestMarginPills).toHaveLength(1);
     expect(leastWastePills).toHaveLength(1);
@@ -249,11 +249,11 @@ describe('BundleCardBase pill badges', () => {
     );
 
     // 3 Least Waste pills (all tie at overage=0)
-    const leastWastePills = await page.getByText('Least Waste').all();
+    const leastWastePills = await page.getByText('Least Waste', { exact: true }).all();
     expect(leastWastePills).toHaveLength(3);
 
     // 1 Best Margin pill (bundleB lowest cost)
-    const bestMarginPills = await page.getByText('Best Margin').all();
+    const bestMarginPills = await page.getByText('Best Margin', { exact: true }).all();
     expect(bestMarginPills).toHaveLength(1);
   });
 });
@@ -274,8 +274,8 @@ describe('Bundle pill badge logic in OrderEntry (integration)', () => {
       />,
     );
 
-    await expect.element(page.getByText('Best Margin')).not.toBeInTheDocument();
-    await expect.element(page.getByText('Least Waste')).not.toBeInTheDocument();
+    await expect.element(page.getByText('Best Margin', { exact: true })).not.toBeInTheDocument();
+    await expect.element(page.getByText('Least Waste', { exact: true })).not.toBeInTheDocument();
   });
 
   test('Best Margin pill shown even when no sell price entered (only based on costTotal)', async () => {
@@ -294,6 +294,6 @@ describe('Bundle pill badge logic in OrderEntry (integration)', () => {
     );
 
     // No price entered, but pill should still show
-    await expect.element(page.getByText('Best Margin')).toBeVisible();
+    await expect.element(page.getByText('Best Margin', { exact: true })).toBeVisible();
   });
 });

--- a/apps/web/tests/component/order-entry-sqft.test.tsx
+++ b/apps/web/tests/component/order-entry-sqft.test.tsx
@@ -70,7 +70,7 @@ async function switchToSearchByUoMSqft(screen: ReturnType<typeof render>) {
   await expect.element(screen.getByRole('button', { name: 'Search by UoM' })).toBeVisible();
   await screen.getByRole('button', { name: 'Search by UoM' }).click();
   // Switch to Sqft toggle
-  await screen.getByRole('button', { name: 'Sqft' }).click();
+  await screen.getByRole('button', { name: 'Sq ft' }).click();
 }
 
 describe('OrderEntry — Search by UoM / Sqft mode', () => {

--- a/apps/web/tests/component/order-entry-ux-polish.test.tsx
+++ b/apps/web/tests/component/order-entry-ux-polish.test.tsx
@@ -1,0 +1,213 @@
+import { test, expect, describe, beforeEach } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { commands } from '@vitest/browser/context';
+import { page } from '@vitest/browser/context';
+import React from 'react';
+import { OrderEntry } from '../../src/components/OrderEntry';
+import { BundleCardBase } from '../../src/components/order-entry/BundleCardBase';
+import type { Bundle, Product } from 'core';
+
+// --- Helpers ---
+
+const makeProduct = (
+  id: string,
+  name: string,
+  sku: string,
+  costPerEach: number,
+  widthInches = 48,
+  lengthInches = 120,
+): Product => ({
+  id,
+  created_at: '2024-01-01T00:00:00Z',
+  properties: {
+    name,
+    sku,
+    material: 'Galvanized Steel',
+    width_inches: widthInches,
+    length_inches: lengthInches,
+    weight_per_sqft: 0.58,
+    cost_per_each: costPerEach,
+    cost_per_linft: null,
+    cost_per_sqft: null,
+    primary_cost_basis: 'each',
+    margin_target: 25,
+    margin_floor: 15,
+  },
+});
+
+const makeBundle = (
+  items: Array<{ product: Product; quantity: number }>,
+  overage: number,
+): Bundle => {
+  const totalSqft = items.reduce(
+    (sum, i) =>
+      sum +
+      i.quantity * ((i.product.properties.width_inches * i.product.properties.length_inches) / 144),
+    0,
+  );
+  const totalLinft = items.reduce(
+    (sum, i) => sum + i.quantity * (i.product.properties.length_inches / 12),
+    0,
+  );
+  const costTotal = items.reduce(
+    (sum, i) => sum + i.quantity * (i.product.properties.cost_per_each ?? 0),
+    0,
+  );
+  return {
+    items,
+    totalSqft,
+    totalLinft,
+    overage,
+    overageUnit: 'linft',
+    costTotal,
+    pricePerSqft: totalSqft === 0 ? 0 : costTotal / totalSqft,
+    pricePerLinft: totalLinft === 0 ? 0 : costTotal / totalLinft,
+  };
+};
+
+const noopCreateOrders = () => {};
+
+const productA = makeProduct('prod-a', 'Alpha Mesh', 'SKU-A', 32.0);
+const productB = makeProduct('prod-b', 'Beta Mesh', 'SKU-B', 20.0);
+
+// --- Tests ---
+
+describe('Linft bundle card shows total delivered length alongside overage', () => {
+  test('linft bundle with overage shows "X ft delivered — Y ft overage"', async () => {
+    // 20 rolls * 10 ft = 200 ft totalLinft, overage = 5 (already in linft)
+    const bundle = makeBundle([{ product: productA, quantity: 20 }], 5);
+
+    render(
+      <BundleCardBase
+        bundle={bundle}
+        bundleKey="test-overage"
+        displayMode="linft"
+        customer=""
+        onCreateOrders={noopCreateOrders}
+      />,
+    );
+
+    await expect.element(page.getByText(/200 ft delivered/)).toBeVisible();
+    await expect.element(page.getByText(/5 ft overage/)).toBeVisible();
+  });
+
+  test('linft bundle with no overage shows "X ft delivered — no waste"', async () => {
+    const bundle = makeBundle([{ product: productA, quantity: 20 }], 0);
+
+    render(
+      <BundleCardBase
+        bundle={bundle}
+        bundleKey="test-no-waste"
+        displayMode="linft"
+        customer=""
+        onCreateOrders={noopCreateOrders}
+      />,
+    );
+
+    await expect.element(page.getByText(/200 ft delivered/)).toBeVisible();
+    await expect.element(page.getByText(/no waste/)).toBeVisible();
+  });
+});
+
+describe('Pill badges explanatory sub-text', () => {
+  test('explanatory text appears when at least one pill is visible', async () => {
+    const bundleA = makeBundle([{ product: productA, quantity: 20 }], 0);
+    const bundleB = makeBundle([{ product: productB, quantity: 20 }], 2);
+
+    render(
+      <div>
+        <BundleCardBase
+          bundle={bundleA}
+          bundleKey="card-a"
+          displayMode="linft"
+          customer=""
+          onCreateOrders={noopCreateOrders}
+          isBestMargin={false}
+          isLeastWaste={true}
+        />
+        <BundleCardBase
+          bundle={bundleB}
+          bundleKey="card-b"
+          displayMode="linft"
+          customer=""
+          onCreateOrders={noopCreateOrders}
+          isBestMargin={true}
+          isLeastWaste={false}
+        />
+      </div>,
+    );
+
+    // Verify pills are shown
+    await expect.element(page.getByText('Best Margin', { exact: true })).toBeVisible();
+    await expect.element(page.getByText('Least Waste', { exact: true })).toBeVisible();
+
+    // Verify explanatory text appears below pill rows
+    const explanations = await page
+      .getByText(/Best Margin = lowest cost bundle.*Least Waste = least overage/)
+      .all();
+    expect(explanations.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('explanatory text does NOT appear when no pills are visible', async () => {
+    const bundle = makeBundle([{ product: productA, quantity: 20 }], 0);
+
+    render(
+      <BundleCardBase
+        bundle={bundle}
+        bundleKey="no-pills"
+        displayMode="linft"
+        customer=""
+        onCreateOrders={noopCreateOrders}
+        isBestMargin={false}
+        isLeastWaste={false}
+      />,
+    );
+
+    await expect
+      .element(page.getByText('Best Margin = lowest cost bundle'))
+      .not.toBeInTheDocument();
+  });
+});
+
+describe('OrderEntry — linft bundle delivered length (integration)', () => {
+  beforeEach(async () => {
+    await commands.resetFixtureState();
+  });
+
+  test('linft bundle card with overage shows "X ft delivered — Y ft overage" text', async () => {
+    // product48a: 10 ft roll, 48" wide
+    const product48a: Product = {
+      id: 'prod-48a',
+      created_at: '2024-01-01T00:00:00Z',
+      properties: {
+        name: '4x4 Welded Wire Mesh',
+        sku: 'WM-48-10FT',
+        material: 'Galvanized Steel',
+        width_inches: 48,
+        length_inches: 120,
+        weight_per_sqft: 0.58,
+        cost_per_each: 32.0,
+        cost_per_linft: null,
+        cost_per_sqft: null,
+        primary_cost_basis: 'each',
+        margin_target: 25,
+        margin_floor: 15,
+      },
+    };
+
+    await commands.setFixtureState({ state: { products: [product48a] } });
+
+    const screen = render(<OrderEntry />);
+
+    // Switch to Search by UoM
+    await expect.element(screen.getByRole('button', { name: 'Search by UoM' })).toBeVisible();
+    await screen.getByRole('button', { name: 'Search by UoM' }).click();
+
+    // 205 ft requested, 10 ft per roll -> 21 rolls, 210 ft delivered, 5 ft overage
+    await screen.getByLabelText('Width').selectOptions('48');
+    await screen.getByLabelText('Total Length (ft)').fill('205');
+
+    await expect.element(screen.getByText(/210 ft delivered/)).toBeVisible();
+    await expect.element(screen.getByText(/5 ft overage/)).toBeVisible();
+  });
+});

--- a/apps/web/tests/component/order-entry-width-match.test.tsx
+++ b/apps/web/tests/component/order-entry-width-match.test.tsx
@@ -77,14 +77,14 @@ describe('OrderEntry — Search by UoM / Linear ft mode', () => {
     await commands.resetFixtureState();
   });
 
-  test('Search by UoM has a Linear ft / Sqft toggle', async () => {
+  test('Search by UoM has a Linear ft / Sq ft toggle', async () => {
     await commands.setFixtureState({ state: { products: ALL_PRODUCTS } });
 
     const screen = render(<OrderEntry />);
     await switchToSearchByUoM(screen);
 
     await expect.element(screen.getByRole('button', { name: 'Linear ft' })).toBeVisible();
-    await expect.element(screen.getByRole('button', { name: 'Sqft' })).toBeVisible();
+    await expect.element(screen.getByRole('button', { name: 'Sq ft' })).toBeVisible();
   });
 
   test('Linear ft mode shows width dropdown populated from distinct width_inches values', async () => {
@@ -152,8 +152,8 @@ describe('OrderEntry — Search by UoM / Linear ft mode', () => {
     await expect.element(screen.getByText('4x4 Welded Wire Mesh')).toBeVisible();
     await expect.element(screen.getByText('WM-48-10FT')).toBeVisible();
     await expect.element(screen.getByText(/20.*rolls/)).toBeVisible();
-    // 20 rolls * 10 ft = 200 ft
-    await expect.element(screen.getByText(/200.*ft/)).toBeVisible();
+    // 20 rolls * 10 ft = 200 ft delivered — no waste
+    await expect.element(screen.getByText(/200 ft delivered/)).toBeVisible();
     await expect.element(screen.getByText(/no waste/)).toBeVisible();
   });
 

--- a/apps/web/tests/component/order-entry.test.tsx
+++ b/apps/web/tests/component/order-entry.test.tsx
@@ -60,14 +60,14 @@ describe('OrderEntry — Specific Product mode', () => {
     await expect.element(screen.getByText(/Galvanized Steel/)).toBeVisible();
   });
 
-  test('sell price label reads "Sell price per each ($)"', async () => {
+  test('sell price label reads "Sell price per roll ($)"', async () => {
     await commands.setFixtureState({ state: { products: [fixtureProduct] } });
 
     const screen = render(<OrderEntry />);
 
     await waitAndSelectProduct(screen);
 
-    await expect.element(screen.getByLabelText('Sell price per each ($)')).toBeVisible();
+    await expect.element(screen.getByLabelText('Sell price per roll ($)')).toBeVisible();
   });
 
   test('default sell price on product selection is target-margin per-each rate', async () => {
@@ -78,7 +78,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
 
     // 32 / (1 - 0.25) = 42.666... => "42.67"
-    await expect.element(screen.getByLabelText('Sell price per each ($)')).toHaveValue(42.67);
+    await expect.element(screen.getByLabelText('Sell price per roll ($)')).toHaveValue(42.67);
   });
 
   test('entering quantity and UOM shows converted quantities in all three units', async () => {
@@ -89,7 +89,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // Default UOM is square_foot; 200 sqft = 5 eaches = 50 linear feet
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByText(/5.*units/)).toBeVisible();
     await expect.element(screen.getByText(/50.*lin ft/)).toBeVisible();
@@ -104,7 +104,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // With $42.67/each, sqftPerEach=40, linftPerEach=10:
     // pricePerSqft = 42.67 / 40 = 1.07, pricePerLinft = 42.67 / 10 = 4.27
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByText(/\$1\.07 \/ sqft/)).toBeVisible();
     await expect.element(screen.getByText(/\$4\.27 \/ linft/)).toBeVisible();
@@ -119,7 +119,7 @@ describe('OrderEntry — Specific Product mode', () => {
     // 200 sqft = 5 eaches; $42.67/each => revenue = 5 * 42.67 = 213.35
     // cost = 5 * 32 = 160; margin = (213.35 - 160) / 213.35 = 25%
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByText(/213\.35/)).toBeVisible();
     await expect.element(screen.getByText(/160/)).toBeVisible();
@@ -133,7 +133,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $50/each: Revenue = 250, Cost = 5 × 32 = 160, Margin = 90/250 = 36%
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('50');
+    await screen.getByLabelText('Sell price per roll ($)').fill('50');
 
     await expect.element(screen.getByText(/250/)).toBeVisible();
     await expect.element(screen.getByText(/160/)).toBeVisible();
@@ -148,7 +148,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $50/each → 36% margin — above 25% target → healthy/green
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('50');
+    await screen.getByLabelText('Sell price per roll ($)').fill('50');
 
     const marginSection = screen.getByText('36.0%');
     await expect.element(marginSection).toBeVisible();
@@ -164,7 +164,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $38/each: Revenue = 190, Cost = 160, Margin = 30/190 = 15.8% — between 15% floor and 25% target
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('38');
+    await screen.getByLabelText('Sell price per roll ($)').fill('38');
 
     const marginSection = screen.getByText('15.8%');
     await expect.element(marginSection).toBeVisible();
@@ -180,7 +180,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches at $36/each: Revenue = 180, Cost = 160, Margin = 20/180 = 11.1% — below 15% floor
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('36');
+    await screen.getByLabelText('Sell price per roll ($)').fill('36');
 
     const marginSection = screen.getByText('11.1%');
     await expect.element(marginSection).toBeVisible();
@@ -196,7 +196,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 100 sqft / 40 sqft per each = 2.5 eaches (fractional)
     await screen.getByLabelText('Quantity').fill('100');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     // ceil(2.5) = 3, 3 * 40 = 120 sqft; floor(2.5) = 2, 2 * 40 = 80 sqft
     await expect
@@ -214,7 +214,7 @@ describe('OrderEntry — Specific Product mode', () => {
 
     await waitAndSelectProduct(screen);
     await screen.getByLabelText('Quantity').fill('100');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await screen.getByRole('button', { name: /Round up to 3 eaches \(120 sqft\)/ }).click();
 
@@ -234,7 +234,7 @@ describe('OrderEntry — Specific Product mode', () => {
 
     await waitAndSelectProduct(screen);
     await screen.getByLabelText('Quantity').fill('100');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await screen.getByRole('button', { name: /Round down to 2 eaches \(80 sqft\)/ }).click();
 
@@ -255,7 +255,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await waitAndSelectProduct(screen);
     // 200 sqft = 5 eaches (integer) — no rounding buttons
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     await expect.element(screen.getByRole('button', { name: /Round up/ })).not.toBeInTheDocument();
     await expect
@@ -271,7 +271,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await screen.getByLabelText('Customer').fill('Acme Fencing Co');
     await waitAndSelectProduct(screen);
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('50');
+    await screen.getByLabelText('Sell price per roll ($)').fill('50');
 
     await screen.getByRole('button', { name: 'Confirm Order' }).click();
 
@@ -296,7 +296,7 @@ describe('OrderEntry — Specific Product mode', () => {
     await expect.element(screen.getByLabelText('Quantity')).toHaveAttribute('tabindex', '3');
     await expect.element(screen.getByLabelText('Unit of measure')).toHaveAttribute('tabindex', '4');
     await expect
-      .element(screen.getByLabelText('Sell price per each ($)'))
+      .element(screen.getByLabelText('Sell price per roll ($)'))
       .toHaveAttribute('tabindex', '5');
     await expect
       .element(screen.getByRole('button', { name: 'Confirm Order' }))
@@ -334,7 +334,7 @@ describe('OrderEntry — Specific Product mode', () => {
     // Margin = 53.35 / 213.35 = 24.9941...% — displays as "25.0%" but raw is below 25%
     // Fix 2 ensures evaluateMargin uses the rounded display value → healthy/green
     await screen.getByLabelText('Quantity').fill('200');
-    await screen.getByLabelText('Sell price per each ($)').fill('42.67');
+    await screen.getByLabelText('Sell price per roll ($)').fill('42.67');
 
     const marginSection = screen.getByText('25.0%');
     await expect.element(marginSection).toBeVisible();

--- a/implementation-plan.md
+++ b/implementation-plan.md
@@ -1,0 +1,13 @@
+# Implementation Plan: Issue #56 — Order Entry UX Polish
+
+## Tasks
+
+- [x] Linft bundle cards show total delivered length alongside overage
+- [x] Fix linft overage calculation (overage already in linft, no conversion needed)
+- [x] Pill badges section shows brief explanatory line when at least one pill is visible
+- [x] "Sqft" toggle label reads "Sq ft"
+- [x] Sell price label reads "Sell price per roll ($)"
+- [x] Update existing tests for new label text
+- [x] Update pill badge tests to use exact matching (avoid matching explanatory text)
+- [x] Add component test: linft bundle card with overage — verify "X ft delivered — Y ft overage"
+- [x] Add component test: 2+ bundles shown — verify explanatory text appears below pill row


### PR DESCRIPTION
## Summary

Implements #56. Closes #56.

## Status

🚧 Work in progress

## Test plan

See #56 for acceptance criteria and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)