### PR TITLE
feat: add Role type and extend UserProperties with role + display_name

### DIFF
--- a/packages/core/types.test.ts
+++ b/packages/core/types.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type {
+  Role,
+  UserProperties,
   UnitOfMeasure,
   CostBasis,
   OrderStatus,
@@ -10,6 +12,29 @@ import type {
   Product,
   Order,
 } from './types';
+
+describe('Role type', () => {
+  it('Role accepts valid values', () => {
+    const a: Role = 'sales_rep';
+    const b: Role = 'inventory_manager';
+    const c: Role = 'admin';
+    expectTypeOf(a).toMatchTypeOf<Role>();
+    expectTypeOf(b).toMatchTypeOf<Role>();
+    expectTypeOf(c).toMatchTypeOf<Role>();
+  });
+
+  it('UserProperties includes role and display_name', () => {
+    const user: UserProperties = {
+      username: 'jsmith',
+      password_hash: 'hash',
+      role: 'sales_rep',
+      display_name: 'John Smith',
+    };
+    expectTypeOf(user).toMatchTypeOf<UserProperties>();
+    expectTypeOf(user.role).toMatchTypeOf<Role>();
+    expectTypeOf(user.display_name).toMatchTypeOf<string>();
+  });
+});
 
 describe('domain types', () => {
   it('UnitOfMeasure covers the three units', () => {

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -19,9 +19,13 @@ export interface Relation {
   created_at: string;
 }
 
+export type Role = 'sales_rep' | 'inventory_manager' | 'admin';
+
 export interface UserProperties {
   username: string;
   password_hash: string;
+  role: Role;
+  display_name: string;
 }
 
 // --- Domain types ---


### PR DESCRIPTION
## Summary

Implements #67.

- Adds `Role` union type (`'sales_rep' | 'inventory_manager' | 'admin'`) exported from `packages/core`
- Extends `UserProperties` with `role: Role` and `display_name: string`
- Adds type tests for `Role` and updated `UserProperties`

## Test plan

See #67 for acceptance criteria and test plan.