### PR TITLE
feat: add inventory_txn entity type

### DIFF
--- a/packages/core/types.test.ts
+++ b/packages/core/types.test.ts
@@ -11,6 +11,9 @@ import type {
   MarginResult,
   Product,
   Order,
+  InventoryTxnType,
+  InventoryTxnProperties,
+  EntityType,
 } from './types';
 
 describe('Role type', () => {
@@ -134,5 +137,36 @@ describe('domain types', () => {
     expectTypeOf<Order>().toHaveProperty('id');
     expectTypeOf<Order>().toHaveProperty('created_at');
     expectTypeOf<Order>().toHaveProperty('properties');
+  });
+
+  it('EntityType includes inventory_txn', () => {
+    const txn: EntityType = 'inventory_txn';
+    expectTypeOf(txn).toMatchTypeOf<EntityType>();
+  });
+
+  it('InventoryTxnType covers all five variants', () => {
+    const a: InventoryTxnType = 'initial';
+    const b: InventoryTxnType = 'receipt';
+    const c: InventoryTxnType = 'adjustment';
+    const d: InventoryTxnType = 'shipment';
+    const e: InventoryTxnType = 'return';
+    expectTypeOf(a).toMatchTypeOf<InventoryTxnType>();
+    expectTypeOf(b).toMatchTypeOf<InventoryTxnType>();
+    expectTypeOf(c).toMatchTypeOf<InventoryTxnType>();
+    expectTypeOf(d).toMatchTypeOf<InventoryTxnType>();
+    expectTypeOf(e).toMatchTypeOf<InventoryTxnType>();
+  });
+
+  it('InventoryTxnProperties has all required fields', () => {
+    const txn: InventoryTxnProperties = {
+      product_id: 'prod-1',
+      product_sku: 'WM-4x4-10GA',
+      txn_type: 'receipt',
+      qty_eaches: 100,
+      reference: 'PO-2024-001',
+      balance_after: 250,
+      created_by: 'user-1',
+    };
+    expectTypeOf(txn).toMatchTypeOf<InventoryTxnProperties>();
   });
 });

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -1,4 +1,4 @@
-export type EntityType = 'user' | 'product' | 'order';
+export type EntityType = 'user' | 'product' | 'order' | 'inventory_txn';
 
 export interface Entity {
   id: string;
@@ -26,6 +26,22 @@ export interface UserProperties {
   password_hash: string;
   role: Role;
   display_name: string;
+}
+
+// --- Domain types ---
+
+// --- Inventory transaction types ---
+
+export type InventoryTxnType = 'initial' | 'receipt' | 'adjustment' | 'shipment' | 'return';
+
+export interface InventoryTxnProperties {
+  product_id: string;
+  product_sku: string;
+  txn_type: InventoryTxnType;
+  qty_eaches: number;
+  reference: string;
+  balance_after: number;
+  created_by: string;
 }
 
 // --- Domain types ---


### PR DESCRIPTION
## Summary

Implements #74.

- Adds `InventoryTxnType = 'initial' | 'receipt' | 'adjustment' | 'shipment' | 'return'`
- Adds `InventoryTxnProperties` interface with `product_id`, `product_sku`, `txn_type`, `qty_eaches`, `reference`, `balance_after`, `created_by`
- Extends `EntityType` union with `'inventory_txn'`
- Adds type tests covering all new types

## Status

Work in progress — CI running.

## Test plan

See #74 for acceptance criteria and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)