### PR TITLE
feat: add shipped order status

### DIFF
--- a/apps/server/src/api/orders.ts
+++ b/apps/server/src/api/orders.ts
@@ -211,6 +211,8 @@ export async function handleOrdersRequest(req: Request, url: URL): Promise<Respo
         confirmed_at: null,
         cancelled_by: null,
         cancelled_at: null,
+        shipped_by: null,
+        shipped_at: null,
       };
 
       const id = crypto.randomUUID();
@@ -270,7 +272,8 @@ export async function handleOrdersRequest(req: Request, url: URL): Promise<Respo
       if (newStatus !== undefined && newStatus !== currentStatus) {
         const validTransitions: Record<string, string[]> = {
           draft: ['confirmed', 'cancelled'],
-          confirmed: ['cancelled'],
+          confirmed: ['shipped', 'cancelled'],
+          shipped: [],
           cancelled: [],
         };
 
@@ -304,6 +307,9 @@ export async function handleOrdersRequest(req: Request, url: URL): Promise<Respo
         } else if (newStatus === 'cancelled') {
           updatedProps.cancelled_by = user.id;
           updatedProps.cancelled_at = now;
+        } else if (newStatus === 'shipped') {
+          updatedProps.shipped_by = user.id;
+          updatedProps.shipped_at = now;
         }
       }
 

--- a/apps/server/tests/integration/orders.test.ts
+++ b/apps/server/tests/integration/orders.test.ts
@@ -703,6 +703,134 @@ test('POST /api/orders returns 201 when margin equals exactly the floor (inclusi
 });
 
 // ---------------------------------------------------------------------------
+// PATCH /api/orders/:id — shipped status transitions
+// ---------------------------------------------------------------------------
+
+test('PATCH /api/orders/:id confirm then ship succeeds', async () => {
+  const product = await createTestProduct();
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Ship Test Customer',
+      product_id: product.id,
+      quantity: 5,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+
+  // Confirm the order
+  const confirmRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(confirmRes.status).toBe(200);
+  const confirmed = await confirmRes.json();
+  expect(confirmed.properties.status).toBe('confirmed');
+
+  // Ship the confirmed order
+  const shipRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+  expect(shipRes.status).toBe(200);
+  const shipped = await shipRes.json();
+  expect(shipped.properties.status).toBe('shipped');
+  expect(shipped.properties.shipped_by).toBe(userId);
+  expect(shipped.properties.shipped_at).toBeTruthy();
+});
+
+test('PATCH /api/orders/:id ship a draft order fails (invalid transition)', async () => {
+  const product = await createTestProduct();
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Draft Ship Fail Customer',
+      product_id: product.id,
+      quantity: 3,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+  expect(order.properties.status).toBe('draft');
+
+  // Attempt to ship directly from draft — should fail
+  const shipRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+  expect(shipRes.status).toBe(400);
+  const body = await shipRes.json();
+  expect(body.error).toBeTruthy();
+});
+
+test('PATCH /api/orders/:id transition from shipped to any status fails', async () => {
+  const product = await createTestProduct();
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({
+      customer: 'Shipped Terminal Customer',
+      product_id: product.id,
+      quantity: 2,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+
+  // Confirm then ship
+  await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  const shipRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+  expect(shipRes.status).toBe(200);
+
+  // Try shipped -> cancelled
+  const cancelRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'cancelled' }),
+  });
+  expect(cancelRes.status).toBe(400);
+
+  // Try shipped -> confirmed
+  const confirmRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(confirmRes.status).toBe(400);
+
+  // Try shipped -> draft
+  const draftRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    body: JSON.stringify({ status: 'draft' }),
+  });
+  expect(draftRes.status).toBe(400);
+});
+
+// ---------------------------------------------------------------------------
 // POST /api/orders — malformed body
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/components/OrderHistory.tsx
+++ b/apps/web/src/components/OrderHistory.tsx
@@ -11,6 +11,7 @@ const STATUS_LABELS: Record<OrderStatus, string> = {
   draft: 'Draft',
   confirmed: 'Confirmed',
   cancelled: 'Cancelled',
+  shipped: 'Shipped',
 };
 
 function formatCurrency(value: number): string {

--- a/packages/core/types.test.ts
+++ b/packages/core/types.test.ts
@@ -81,6 +81,8 @@ describe('domain types', () => {
       confirmed_at: null,
       cancelled_by: null,
       cancelled_at: null,
+      shipped_by: null,
+      shipped_at: null,
     };
     expectTypeOf(order).toMatchTypeOf<OrderProperties>();
   });

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -30,7 +30,7 @@ export type UnitOfMeasure = 'each' | 'linear_foot' | 'square_foot';
 
 export type CostBasis = 'each' | 'linear_foot' | 'square_foot';
 
-export type OrderStatus = 'draft' | 'confirmed' | 'cancelled';
+export type OrderStatus = 'draft' | 'confirmed' | 'cancelled' | 'shipped';
 
 export interface ProductProperties {
   name: string;
@@ -77,6 +77,8 @@ export interface OrderProperties {
   confirmed_at: string | null;
   cancelled_by: string | null;
   cancelled_at: string | null;
+  shipped_by: string | null;
+  shipped_at: string | null;
 }
 
 export interface UnitConversions {


### PR DESCRIPTION
## Summary

Implements #76.

- Extends `OrderStatus` to `'draft' | 'confirmed' | 'cancelled' | 'shipped'`
- Adds `shipped_by: string | null` and `shipped_at: string | null` to `OrderProperties`
- Updates status transition map: `confirmed → shipped` allowed, `shipped → *` blocked (terminal)
- Adds `shipped` label to `OrderHistory` component STATUS_LABELS map
- Integration tests: confirm-then-ship succeeds, draft-to-ship fails, all shipped→* transitions fail

## Test plan

- Integration test: confirm then ship an order — succeeds
- Integration test: ship a draft order — fails (invalid transition)
- Integration test: transition from shipped to any status — fails