### PR TITLE
feat: extend JWT payload with role and add requireRole() middleware

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "postgres": "^3.4.8",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/apps/server/src/api/auth.ts
+++ b/apps/server/src/api/auth.ts
@@ -1,4 +1,5 @@
 import { sql } from 'db';
+import type { Role } from 'core';
 import { signJwt, verifyJwt } from '../auth/jwt';
 
 // Helper to parse cookies from headers
@@ -15,23 +16,6 @@ export function parseCookies(cookieHeader: string | null): Record<string, string
   return cookies;
 }
 
-// Helper to verify auth from a Request object
-export async function getAuthenticatedUser(
-  req: Request,
-): Promise<{ id: string; username: string } | null> {
-  const cookies = parseCookies(req.headers.get('Cookie'));
-  const token = cookies['meshmargin_auth'];
-
-  if (!token) return null;
-
-  try {
-    const payload = await verifyJwt<{ id: string; username: string }>(token);
-    return payload;
-  } catch {
-    return null;
-  }
-}
-
 // Helper to get CORS headers dynamically
 export function getCorsHeaders(req: Request): Record<string, string> {
   const origin = req.headers.get('Origin') || 'http://localhost:5174';
@@ -39,6 +23,60 @@ export function getCorsHeaders(req: Request): Record<string, string> {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Allow-Headers': 'Content-Type',
+  };
+}
+
+// Helper to verify auth from a Request object
+export async function getAuthenticatedUser(
+  req: Request,
+): Promise<{ id: string; username: string; role: Role } | null> {
+  const cookies = parseCookies(req.headers.get('Cookie'));
+  const token = cookies['meshmargin_auth'];
+
+  if (!token) return null;
+
+  try {
+    const payload = await verifyJwt<{ id: string; username: string; role: Role }>(token);
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns a middleware function that checks if the authenticated user has one
+ * of the allowed roles. Returns a 403 Forbidden response if the user's role is
+ * not in the allowed list, or 401 if unauthenticated.
+ */
+export function requireRole(...allowed: Role[]): (req: Request) => Promise<Response | null> {
+  return async (req: Request): Promise<Response | null> => {
+    const corsHeaders = getCorsHeaders(req);
+    const user = await getAuthenticatedUser(req);
+
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (!allowed.includes(user.role)) {
+      const required_role = allowed[0];
+      return new Response(
+        JSON.stringify({
+          error: 'Forbidden',
+          message: `This action requires the ${required_role} role.`,
+          required_role,
+          current_role: user.role,
+        }),
+        {
+          status: 403,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    return null;
   };
 }
 
@@ -76,20 +114,22 @@ export async function handleAuthRequest(req: Request, url: URL): Promise<Respons
 
       const id = crypto.randomUUID();
       const hash = await Bun.password.hash(password);
+      const role: Role = 'sales_rep';
 
       const properties = {
         username,
         password_hash: hash,
+        role,
       };
 
       await sql`
-                INSERT INTO entities (id, type, properties, tenant_id) 
+                INSERT INTO entities (id, type, properties, tenant_id)
                 VALUES (${id}, 'user', ${sql.json(properties)}, null)
             `;
 
-      const token = await signJwt({ id, username });
+      const token = await signJwt({ id, username, role });
 
-      return new Response(JSON.stringify({ user: { id, username } }), {
+      return new Response(JSON.stringify({ user: { id, username, role } }), {
         status: 201,
         headers: {
           ...corsHeaders,
@@ -113,8 +153,8 @@ export async function handleAuthRequest(req: Request, url: URL): Promise<Respons
 
       // Retrieve User Entity
       const users = await sql`
-                SELECT id, properties->>'username' as username, properties->>'password_hash' as password_hash 
-                FROM entities 
+                SELECT id, properties->>'username' as username, properties->>'password_hash' as password_hash, properties->>'role' as role
+                FROM entities
                 WHERE type = 'user' AND properties->>'username' = ${username}
             `;
 
@@ -135,16 +175,20 @@ export async function handleAuthRequest(req: Request, url: URL): Promise<Respons
         });
       }
 
-      const token = await signJwt({ id: user.id, username: user.username });
+      const role: Role = (user.role as Role) ?? 'sales_rep';
+      const token = await signJwt({ id: user.id, username: user.username, role });
 
-      return new Response(JSON.stringify({ user: { id: user.id, username: user.username } }), {
-        status: 200,
-        headers: {
-          ...corsHeaders,
-          'Content-Type': 'application/json',
-          'Set-Cookie': `meshmargin_auth=${token}; HttpOnly; Path=/; SameSite=Lax; Max-Age=604800`,
+      return new Response(
+        JSON.stringify({ user: { id: user.id, username: user.username, role } }),
+        {
+          status: 200,
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'application/json',
+            'Set-Cookie': `meshmargin_auth=${token}; HttpOnly; Path=/; SameSite=Lax; Max-Age=604800`,
+          },
         },
-      });
+      );
     } catch (err) {
       console.error('LOGIN ERROR:', err);
       return new Response(JSON.stringify({ error: 'Internal Server Error' }), {

--- a/apps/server/tests/integration/auth-role.test.ts
+++ b/apps/server/tests/integration/auth-role.test.ts
@@ -1,0 +1,222 @@
+import { test, expect, beforeAll, afterAll } from 'vitest';
+import type { Subprocess } from 'bun';
+import postgres from 'postgres';
+import { startPostgres, type PgContainer } from '../helpers/pg-container';
+
+/**
+ * Integration tests for JWT role payload and requireRole() middleware.
+ *
+ * Verifies:
+ * - Login response JWT contains the role field
+ * - Register response JWT contains the role field
+ * - getAuthenticatedUser returns { id, username, role }
+ * - requireRole blocks unauthorized roles with 403
+ * - requireRole allows authorized roles
+ */
+
+const PORT = 31420;
+const BASE = `http://localhost:${PORT}`;
+const SERVER_READY_TIMEOUT_MS = 20_000;
+const REPO_ROOT = new URL('../../../../', import.meta.url).pathname;
+const SERVER_ENTRY = 'apps/server/src/index.ts';
+
+let pg: PgContainer;
+let server: Subprocess;
+let salesRepCookie = '';
+let inventoryManagerCookie = '';
+
+beforeAll(async () => {
+  pg = await startPostgres();
+
+  server = Bun.spawn(['bun', 'run', SERVER_ENTRY], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, DATABASE_URL: pg.url, PORT: String(PORT) },
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+
+  await waitForServer(BASE);
+
+  // Register a sales_rep user via the API (default role)
+  const salesRepUsername = `sales_rep_test_${Date.now()}`;
+  const salesRes = await fetch(`${BASE}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: salesRepUsername, password: 'testpass123' }),
+  });
+  expect(salesRes.status).toBe(201);
+  const salesSetCookie = salesRes.headers.get('set-cookie') ?? '';
+  salesRepCookie = salesSetCookie.split(';')[0];
+
+  // Insert an inventory_manager user directly into the database
+  const sql = postgres(pg.url, { max: 1 });
+  const invMgrUsername = `inv_mgr_test_${Date.now()}`;
+  const invMgrId = crypto.randomUUID();
+  const invMgrHash = await Bun.password.hash('testpass123');
+  await sql`
+    INSERT INTO entities (id, type, properties, tenant_id)
+    VALUES (
+      ${invMgrId},
+      'user',
+      ${sql.json({ username: invMgrUsername, password_hash: invMgrHash, role: 'inventory_manager', display_name: 'Test Inventory Manager' })},
+      null
+    )
+  `;
+  await sql.end();
+
+  // Log in as the inventory_manager
+  const invMgrRes = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: invMgrUsername, password: 'testpass123' }),
+  });
+  expect(invMgrRes.status).toBe(200);
+  const invMgrSetCookie = invMgrRes.headers.get('set-cookie') ?? '';
+  inventoryManagerCookie = invMgrSetCookie.split(';')[0];
+}, 60_000);
+
+afterAll(async () => {
+  server?.kill();
+  await pg?.stop();
+});
+
+// ---------------------------------------------------------------------------
+// JWT role tests
+// ---------------------------------------------------------------------------
+
+test('POST /api/auth/register response includes role field for new user', async () => {
+  const username = `role_test_${Date.now()}`;
+  const res = await fetch(`${BASE}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password: 'testpass123' }),
+  });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body.user.role).toBe('sales_rep');
+});
+
+test('POST /api/auth/login response includes role field', async () => {
+  // Register then login
+  const username = `login_role_test_${Date.now()}`;
+  await fetch(`${BASE}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password: 'testpass123' }),
+  });
+
+  const loginRes = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password: 'testpass123' }),
+  });
+  expect(loginRes.status).toBe(200);
+  const body = await loginRes.json();
+  expect(body.user.role).toBe('sales_rep');
+});
+
+test('GET /api/auth/me returns role in user payload for sales_rep', async () => {
+  const res = await fetch(`${BASE}/api/auth/me`, {
+    headers: { Cookie: salesRepCookie },
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.user.id).toBeTruthy();
+  expect(body.user.username).toBeTruthy();
+  expect(body.user.role).toBe('sales_rep');
+});
+
+test('GET /api/auth/me returns role in user payload for inventory_manager', async () => {
+  const res = await fetch(`${BASE}/api/auth/me`, {
+    headers: { Cookie: inventoryManagerCookie },
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.user.id).toBeTruthy();
+  expect(body.user.username).toBeTruthy();
+  expect(body.user.role).toBe('inventory_manager');
+});
+
+// ---------------------------------------------------------------------------
+// requireRole tests — tested via the requireRole unit test helper
+// ---------------------------------------------------------------------------
+
+test('requireRole blocks sales_rep from inventory_manager-only action', async () => {
+  // The requireRole function is tested here by importing and calling it directly.
+  // We construct a mock Request with the sales_rep session cookie.
+  const { requireRole } = await import('../../src/api/auth');
+
+  const mockReq = new Request(`${BASE}/api/test`, {
+    headers: { Cookie: salesRepCookie },
+  });
+
+  const guard = requireRole('inventory_manager');
+  const res = await guard(mockReq);
+
+  expect(res).not.toBeNull();
+  expect(res!.status).toBe(403);
+  const body = await res!.json();
+  expect(body.error).toBe('Forbidden');
+  expect(body.message).toBe('This action requires the inventory_manager role.');
+  expect(body.required_role).toBe('inventory_manager');
+  expect(body.current_role).toBe('sales_rep');
+});
+
+test('requireRole allows inventory_manager for inventory_manager-only action', async () => {
+  const { requireRole } = await import('../../src/api/auth');
+
+  const mockReq = new Request(`${BASE}/api/test`, {
+    headers: { Cookie: inventoryManagerCookie },
+  });
+
+  const guard = requireRole('inventory_manager');
+  const res = await guard(mockReq);
+
+  expect(res).toBeNull();
+});
+
+test('requireRole allows all roles when all are listed', async () => {
+  const { requireRole } = await import('../../src/api/auth');
+
+  const salesReq = new Request(`${BASE}/api/test`, {
+    headers: { Cookie: salesRepCookie },
+  });
+  const invMgrReq = new Request(`${BASE}/api/test`, {
+    headers: { Cookie: inventoryManagerCookie },
+  });
+
+  const guard = requireRole('sales_rep', 'inventory_manager', 'admin');
+
+  const salesRes = await guard(salesReq);
+  const invMgrRes = await guard(invMgrReq);
+
+  expect(salesRes).toBeNull();
+  expect(invMgrRes).toBeNull();
+});
+
+test('requireRole returns 401 for unauthenticated request', async () => {
+  const { requireRole } = await import('../../src/api/auth');
+
+  const mockReq = new Request(`${BASE}/api/test`);
+  const guard = requireRole('inventory_manager');
+  const res = await guard(mockReq);
+
+  expect(res).not.toBeNull();
+  expect(res!.status).toBe(401);
+});
+
+// ---------------------------------------------------------------------------
+
+/** Poll the server until it responds or we time out. */
+async function waitForServer(base: string): Promise<void> {
+  const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${base}/api/auth/me`);
+      return;
+    } catch {
+      await Bun.sleep(300);
+    }
+  }
+  throw new Error(`Server at ${base} did not become ready within ${SERVER_READY_TIMEOUT_MS}ms`);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "postgres": "^3.4.8",
         "typescript": "^5.0.0",
       },
     },
@@ -321,7 +322,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -435,7 +436,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 


### PR DESCRIPTION
## Summary

Implements #68.

## What was changed

- getAuthenticatedUser now returns { id, username, role: Role } — the JWT payload includes the role field
- signJwt calls in login and register now include role in the payload
- Register assigns 'sales_rep' as the default role for new users
- Login reads the role from the user's DB record and includes it in the JWT
- New requireRole(...allowed: Role[]) function returns a middleware that returns 401 if unauthenticated, 403 with structured error if role not allowed, null if allowed
- Added integration tests covering JWT role field and requireRole behavior

## Test plan

See #68 for acceptance criteria and test plan.