### PR TITLE
feat: add user management endpoints

### DIFF
--- a/apps/server/src/api/users.ts
+++ b/apps/server/src/api/users.ts
@@ -1,0 +1,127 @@
+import { sql } from 'db';
+import type { Role, UserProperties } from 'core';
+import { getCorsHeaders, requireRole } from './auth';
+
+const VALID_ROLES: Role[] = ['sales_rep', 'inventory_manager', 'admin'];
+
+export interface UserSummary {
+  id: string;
+  username: string;
+  role: Role;
+  display_name: string;
+}
+
+function rowToUserSummary(row: { id: string; properties: UserProperties }): UserSummary {
+  return {
+    id: row.id,
+    username: row.properties.username,
+    role: row.properties.role ?? 'sales_rep',
+    display_name: row.properties.display_name ?? '',
+  };
+}
+
+export async function handleUsersRequest(req: Request, url: URL): Promise<Response | null> {
+  const corsHeaders = getCorsHeaders(req);
+
+  if (!url.pathname.startsWith('/api/users')) return null;
+
+  // GET /api/users — admin only
+  if (req.method === 'GET' && url.pathname === '/api/users') {
+    const guard = requireRole('admin');
+    const authError = await guard(req);
+    if (authError) return authError;
+
+    try {
+      const rows = await sql<{ id: string; properties: UserProperties }[]>`
+        SELECT id, properties
+        FROM entities
+        WHERE type = 'user'
+        ORDER BY properties->>'username' ASC
+      `;
+      const users: UserSummary[] = rows.map(rowToUserSummary);
+      return new Response(JSON.stringify(users), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('GET /api/users ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  // PATCH /api/users/:id — admin only
+  const patchMatch = url.pathname.match(/^\/api\/users\/([^/]+)$/);
+  if (req.method === 'PATCH' && patchMatch) {
+    const userId = patchMatch[1];
+
+    const guard = requireRole('admin');
+    const authError = await guard(req);
+    if (authError) return authError;
+
+    try {
+      const body = await req.json();
+
+      // Validate role if provided
+      if (body.role !== undefined) {
+        if (!VALID_ROLES.includes(body.role)) {
+          return new Response(
+            JSON.stringify({
+              error: `Invalid role. Must be one of: ${VALID_ROLES.join(', ')}`,
+            }),
+            {
+              status: 400,
+              headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            },
+          );
+        }
+      }
+
+      // Fetch the existing user
+      const existing = await sql<{ id: string; properties: UserProperties }[]>`
+        SELECT id, properties
+        FROM entities
+        WHERE id = ${userId} AND type = 'user'
+      `;
+
+      if (existing.length === 0) {
+        return new Response(JSON.stringify({ error: 'User not found' }), {
+          status: 404,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const currentProps = existing[0].properties;
+      const updatedProps: UserProperties = {
+        ...currentProps,
+        ...(body.role !== undefined ? { role: body.role as Role } : {}),
+        ...(body.display_name !== undefined ? { display_name: body.display_name } : {}),
+      };
+
+      const rows = await sql<{ id: string; properties: UserProperties }[]>`
+        UPDATE entities
+        SET properties = ${sql.json(JSON.parse(JSON.stringify(updatedProps)))},
+            updated_at = CURRENT_TIMESTAMP,
+            version = version + 1
+        WHERE id = ${userId} AND type = 'user'
+        RETURNING id, properties
+      `;
+
+      const user = rowToUserSummary(rows[0]);
+      return new Response(JSON.stringify(user), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error('PATCH /api/users/:id ERROR:', err);
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  return null;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,6 +10,7 @@ import { handleAuthRequest } from './api/auth';
 import { handleProductsRequest } from './api/products';
 import { handleOrdersRequest } from './api/orders';
 import { handleInventoryRequest } from './api/inventory';
+import { handleUsersRequest } from './api/users';
 
 await migrate();
 await seed(sql);
@@ -49,6 +50,11 @@ export default {
     if (url.pathname.startsWith('/api/inventory')) {
       const inventoryRes = await handleInventoryRequest(req, url);
       if (inventoryRes) return inventoryRes;
+    }
+
+    if (url.pathname.startsWith('/api/users')) {
+      const usersRes = await handleUsersRequest(req, url);
+      if (usersRes) return usersRes;
     }
 
     // Serve static assets — path is relative to this file, not process cwd

--- a/apps/server/tests/integration/users.test.ts
+++ b/apps/server/tests/integration/users.test.ts
@@ -1,0 +1,230 @@
+import { test, expect, beforeAll, afterAll } from 'vitest';
+import type { Subprocess } from 'bun';
+import postgres from 'postgres';
+import { startPostgres, type PgContainer } from '../helpers/pg-container';
+
+/**
+ * Integration tests for user management endpoints (Issue #70).
+ *
+ * Verifies:
+ * - GET /api/users returns user list without password_hash (admin only)
+ * - GET /api/users returns 403 for non-admin
+ * - PATCH /api/users/:id can change role (admin only)
+ * - PATCH /api/users/:id returns 403 for non-admin
+ * - Invalid role values return 400
+ */
+
+const PORT = 31421;
+const BASE = `http://localhost:${PORT}`;
+const SERVER_READY_TIMEOUT_MS = 20_000;
+const REPO_ROOT = new URL('../../../../', import.meta.url).pathname;
+const SERVER_ENTRY = 'apps/server/src/index.ts';
+
+let pg: PgContainer;
+let server: Subprocess;
+let adminCookie = '';
+let salesRepCookie = '';
+let salesRepId = '';
+let adminId = '';
+
+beforeAll(async () => {
+  pg = await startPostgres();
+
+  server = Bun.spawn(['bun', 'run', SERVER_ENTRY], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, DATABASE_URL: pg.url, PORT: String(PORT) },
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+
+  await waitForServer(BASE);
+
+  // Register a sales_rep user via the API (default role)
+  const salesRepUsername = `sales_rep_${Date.now()}`;
+  const salesRes = await fetch(`${BASE}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: salesRepUsername, password: 'testpass123' }),
+  });
+  expect(salesRes.status).toBe(201);
+  const salesSetCookie = salesRes.headers.get('set-cookie') ?? '';
+  salesRepCookie = salesSetCookie.split(';')[0];
+  const salesBody = await salesRes.json();
+  salesRepId = salesBody.user.id;
+
+  // Insert an admin user directly into the database
+  const sql = postgres(pg.url, { max: 1 });
+  const adminUsername = `admin_${Date.now()}`;
+  adminId = crypto.randomUUID();
+  const adminHash = await Bun.password.hash('adminpass123');
+  await sql`
+    INSERT INTO entities (id, type, properties, tenant_id)
+    VALUES (
+      ${adminId},
+      'user',
+      ${sql.json({ username: adminUsername, password_hash: adminHash, role: 'admin', display_name: 'Test Admin' })},
+      null
+    )
+  `;
+  await sql.end();
+
+  // Log in as the admin
+  const adminRes = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: adminUsername, password: 'adminpass123' }),
+  });
+  expect(adminRes.status).toBe(200);
+  const adminSetCookie = adminRes.headers.get('set-cookie') ?? '';
+  adminCookie = adminSetCookie.split(';')[0];
+}, 60_000);
+
+afterAll(async () => {
+  server?.kill();
+  await pg?.stop();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/users tests
+// ---------------------------------------------------------------------------
+
+test('GET /api/users returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/users`);
+  expect(res.status).toBe(401);
+});
+
+test('GET /api/users returns 403 for sales_rep', async () => {
+  const res = await fetch(`${BASE}/api/users`, {
+    headers: { Cookie: salesRepCookie },
+  });
+  expect(res.status).toBe(403);
+  const body = await res.json();
+  expect(body.error).toBe('Forbidden');
+});
+
+test('GET /api/users returns 200 with user list for admin', async () => {
+  const res = await fetch(`${BASE}/api/users`, {
+    headers: { Cookie: adminCookie },
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(Array.isArray(body)).toBe(true);
+  expect(body.length).toBeGreaterThan(0);
+});
+
+test('GET /api/users returns users without password_hash', async () => {
+  const res = await fetch(`${BASE}/api/users`, {
+    headers: { Cookie: adminCookie },
+  });
+  expect(res.status).toBe(200);
+  const users = await res.json();
+  for (const user of users) {
+    expect(user).not.toHaveProperty('password_hash');
+    expect(user).toHaveProperty('id');
+    expect(user).toHaveProperty('username');
+    expect(user).toHaveProperty('role');
+    expect(user).toHaveProperty('display_name');
+  }
+});
+
+test('GET /api/users response includes the registered sales_rep user', async () => {
+  const res = await fetch(`${BASE}/api/users`, {
+    headers: { Cookie: adminCookie },
+  });
+  expect(res.status).toBe(200);
+  const users = await res.json();
+  const found = users.find((u: { id: string }) => u.id === salesRepId);
+  expect(found).toBeTruthy();
+  expect(found.role).toBe('sales_rep');
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/users/:id tests
+// ---------------------------------------------------------------------------
+
+test('PATCH /api/users/:id returns 401 without session', async () => {
+  const res = await fetch(`${BASE}/api/users/${salesRepId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role: 'inventory_manager' }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test('PATCH /api/users/:id returns 403 for sales_rep', async () => {
+  const res = await fetch(`${BASE}/api/users/${salesRepId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: salesRepCookie },
+    body: JSON.stringify({ role: 'inventory_manager' }),
+  });
+  expect(res.status).toBe(403);
+  const body = await res.json();
+  expect(body.error).toBe('Forbidden');
+});
+
+test('PATCH /api/users/:id can change role (admin)', async () => {
+  const res = await fetch(`${BASE}/api/users/${salesRepId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: adminCookie },
+    body: JSON.stringify({ role: 'inventory_manager' }),
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.id).toBe(salesRepId);
+  expect(body.role).toBe('inventory_manager');
+
+  // Verify via GET /api/users
+  const listRes = await fetch(`${BASE}/api/users`, {
+    headers: { Cookie: adminCookie },
+  });
+  const users = await listRes.json();
+  const updated = users.find((u: { id: string }) => u.id === salesRepId);
+  expect(updated.role).toBe('inventory_manager');
+});
+
+test('PATCH /api/users/:id can update display_name (admin)', async () => {
+  const res = await fetch(`${BASE}/api/users/${salesRepId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: adminCookie },
+    body: JSON.stringify({ display_name: 'Updated Name' }),
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.display_name).toBe('Updated Name');
+});
+
+test('PATCH /api/users/:id returns 400 for invalid role', async () => {
+  const res = await fetch(`${BASE}/api/users/${salesRepId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: adminCookie },
+    body: JSON.stringify({ role: 'superuser' }),
+  });
+  expect(res.status).toBe(400);
+  const body = await res.json();
+  expect(body.error).toBeTruthy();
+});
+
+test('PATCH /api/users/:id returns 404 for nonexistent user', async () => {
+  const res = await fetch(`${BASE}/api/users/nonexistent-user-id`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: adminCookie },
+    body: JSON.stringify({ role: 'sales_rep' }),
+  });
+  expect(res.status).toBe(404);
+});
+
+// ---------------------------------------------------------------------------
+
+/** Poll the server until it responds or we time out. */
+async function waitForServer(base: string): Promise<void> {
+  const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${base}/api/auth/me`);
+      return;
+    } catch {
+      await Bun.sleep(300);
+    }
+  }
+  throw new Error(`Server at ${base} did not become ready within ${SERVER_READY_TIMEOUT_MS}ms`);
+}


### PR DESCRIPTION
## Summary

Implements #70.

Adds two admin-only endpoints for user management:
- `GET /api/users` — returns all users (id, username, role, display_name). No password_hash. Requires `admin` role.
- `PATCH /api/users/:id` — updates `role` and/or `display_name`. Requires `admin` role. Validates role is a valid Role value.

Both routes return 403 for non-admins and 401 for unauthenticated requests.

## Status

🚧 Work in progress

## Test plan

See #70 for acceptance criteria and test plan.

Integration tests added in `apps/server/tests/integration/users.test.ts` covering:
- GET /api/users returns 401 without session
- GET /api/users returns 403 for sales_rep
- GET /api/users returns 200 with user list for admin
- GET /api/users returns users without password_hash
- PATCH /api/users/:id returns 401 without session
- PATCH /api/users/:id returns 403 for sales_rep
- PATCH /api/users/:id can change role (admin)
- PATCH /api/users/:id returns 400 for invalid role
- PATCH /api/users/:id returns 404 for nonexistent user

🤖 Generated with [Claude Code](https://claude.com/claude-code)