### PR TITLE
feat: shipped transition on PATCH /api/orders/:id

### DIFF
--- a/apps/server/src/api/orders.ts
+++ b/apps/server/src/api/orders.ts
@@ -1,7 +1,7 @@
 import { sql } from 'db';
-import type { Order, OrderProperties, ProductProperties } from 'core';
+import type { Order, OrderProperties, ProductProperties, InventoryTxnProperties } from 'core';
 import { computeOrderFields } from 'core';
-import { getAuthenticatedUser, getCorsHeaders } from './auth';
+import { getAuthenticatedUser, getCorsHeaders, requireRole } from './auth';
 
 function rowToOrder(row: { id: string; properties: OrderProperties; created_at: string }): Order {
   return {
@@ -289,6 +289,13 @@ export async function handleOrdersRequest(req: Request, url: URL): Promise<Respo
             },
           );
         }
+
+        // Require inventory_manager or admin role for shipped transition
+        if (newStatus === 'shipped') {
+          const roleGuard = requireRole('inventory_manager', 'admin');
+          const roleError = await roleGuard(req);
+          if (roleError) return roleError;
+        }
       }
 
       const updatedProps: OrderProperties = { ...currentProps };
@@ -319,6 +326,61 @@ export async function handleOrdersRequest(req: Request, url: URL): Promise<Respo
         WHERE id = ${orderId} AND type = 'order'
         RETURNING id, properties, created_at
       `;
+
+      // If transitioning to shipped, create inventory_txn and decrement product qty
+      if (newStatus === 'shipped' && newStatus !== currentStatus) {
+        const order = rowToOrder(rows[0]);
+        const qtyChange = -order.properties.qty_eaches;
+
+        // Fetch the product to get current qty and sku
+        const productRows = await sql<
+          { id: string; properties: ProductProperties; created_at: string }[]
+        >`
+          SELECT id, properties, created_at
+          FROM entities
+          WHERE id = ${order.properties.product_id} AND type = 'product'
+        `;
+
+        if (productRows.length > 0) {
+          const product = productRows[0];
+          const newQtyOnHand = (product.properties.qty_on_hand_eaches ?? 0) + qtyChange;
+          const balanceAfter = newQtyOnHand;
+
+          // Create shipment inventory_txn
+          const txnId = crypto.randomUUID();
+          const txnProperties: InventoryTxnProperties = {
+            product_id: order.properties.product_id,
+            product_sku: product.properties.sku,
+            txn_type: 'shipment',
+            qty_eaches: qtyChange,
+            reference: order.id,
+            balance_after: balanceAfter,
+            created_by: user.id,
+          };
+
+          await sql`
+            INSERT INTO entities (id, type, properties, tenant_id)
+            VALUES (${txnId}, 'inventory_txn', ${sql.json(JSON.parse(JSON.stringify(txnProperties)))}, null)
+          `;
+
+          // Update product qty_on_hand_eaches
+          const updatedProductProps: ProductProperties = {
+            ...product.properties,
+            qty_on_hand_eaches: newQtyOnHand,
+          };
+
+          await sql`
+            UPDATE entities
+            SET properties = ${sql.json(JSON.parse(JSON.stringify(updatedProductProps)))}, updated_at = CURRENT_TIMESTAMP, version = version + 1
+            WHERE id = ${order.properties.product_id} AND type = 'product'
+          `;
+        }
+
+        return new Response(JSON.stringify(order), {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
 
       const order = rowToOrder(rows[0]);
       return new Response(JSON.stringify(order), {

--- a/apps/server/tests/integration/orders.test.ts
+++ b/apps/server/tests/integration/orders.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, beforeAll, afterAll } from 'vitest';
 import type { Subprocess } from 'bun';
+import postgres from 'postgres';
 import { startPostgres, type PgContainer } from '../helpers/pg-container';
 
 const PORT = 31418;
@@ -12,6 +13,8 @@ let pg: PgContainer;
 let server: Subprocess;
 let authCookie = '';
 let userId = '';
+let inventoryManagerCookie = '';
+let pgSql: postgres.Sql;
 
 beforeAll(async () => {
   pg = await startPostgres();
@@ -25,7 +28,7 @@ beforeAll(async () => {
 
   await waitForServer(BASE);
 
-  // Register a test user and capture the session cookie
+  // Register a test user (sales_rep) and capture the session cookie
   const username = `test_${Date.now()}`;
   const res = await fetch(`${BASE}/api/auth/register`, {
     method: 'POST',
@@ -37,10 +40,35 @@ beforeAll(async () => {
 
   const body = await res.json();
   userId = body.user.id;
+
+  // Insert an inventory_manager user directly into the database
+  pgSql = postgres(pg.url, { max: 1 });
+  const invMgrUsername = `inv_mgr_orders_test_${Date.now()}`;
+  const invMgrId = crypto.randomUUID();
+  const invMgrHash = await Bun.password.hash('testpass123');
+  await pgSql`
+    INSERT INTO entities (id, type, properties, tenant_id)
+    VALUES (
+      ${invMgrId},
+      'user',
+      ${pgSql.json({ username: invMgrUsername, password_hash: invMgrHash, role: 'inventory_manager', display_name: 'Test Inventory Manager' })},
+      null
+    )
+  `;
+
+  // Log in as the inventory_manager
+  const invMgrRes = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: invMgrUsername, password: 'testpass123' }),
+  });
+  const invMgrSetCookie = invMgrRes.headers.get('set-cookie') ?? '';
+  inventoryManagerCookie = invMgrSetCookie.split(';')[0];
 }, 60_000);
 
 afterAll(async () => {
   server?.kill();
+  await pgSql?.end({ timeout: 5 });
   await pg?.stop();
 });
 
@@ -733,16 +761,15 @@ test('PATCH /api/orders/:id confirm then ship succeeds', async () => {
   const confirmed = await confirmRes.json();
   expect(confirmed.properties.status).toBe('confirmed');
 
-  // Ship the confirmed order
+  // Ship the confirmed order — requires inventory_manager or admin role
   const shipRes = await fetch(`${BASE}/api/orders/${order.id}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    headers: { 'Content-Type': 'application/json', Cookie: inventoryManagerCookie },
     body: JSON.stringify({ status: 'shipped' }),
   });
   expect(shipRes.status).toBe(200);
   const shipped = await shipRes.json();
   expect(shipped.properties.status).toBe('shipped');
-  expect(shipped.properties.shipped_by).toBe(userId);
   expect(shipped.properties.shipped_at).toBeTruthy();
 });
 
@@ -792,7 +819,7 @@ test('PATCH /api/orders/:id transition from shipped to any status fails', async 
   expect(createRes.status).toBe(201);
   const order = await createRes.json();
 
-  // Confirm then ship
+  // Confirm then ship — ship requires inventory_manager or admin role
   await fetch(`${BASE}/api/orders/${order.id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Cookie: authCookie },
@@ -800,7 +827,7 @@ test('PATCH /api/orders/:id transition from shipped to any status fails', async 
   });
   const shipRes = await fetch(`${BASE}/api/orders/${order.id}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', Cookie: authCookie },
+    headers: { 'Content-Type': 'application/json', Cookie: inventoryManagerCookie },
     body: JSON.stringify({ status: 'shipped' }),
   });
   expect(shipRes.status).toBe(200);

--- a/apps/server/tests/integration/shipped-transition.test.ts
+++ b/apps/server/tests/integration/shipped-transition.test.ts
@@ -1,0 +1,285 @@
+import { test, expect, beforeAll, afterAll } from 'vitest';
+import type { Subprocess } from 'bun';
+import postgres from 'postgres';
+import { startPostgres, type PgContainer } from '../helpers/pg-container';
+
+/**
+ * Integration tests for the shipped transition on PATCH /api/orders/:id.
+ *
+ * Verifies:
+ * - confirmed → shipped succeeds for inventory_manager
+ * - Shipment inventory_txn created with negative qty
+ * - Product qty_on_hand decremented
+ * - sales_rep gets 403 for shipped transition
+ * - draft → shipped returns invalid transition error
+ */
+
+const PORT = 31421;
+const BASE = `http://localhost:${PORT}`;
+const SERVER_READY_TIMEOUT_MS = 20_000;
+const REPO_ROOT = new URL('../../../../', import.meta.url).pathname;
+const SERVER_ENTRY = 'apps/server/src/index.ts';
+
+let pg: PgContainer;
+let server: Subprocess;
+let salesRepCookie = '';
+let inventoryManagerCookie = '';
+let inventoryManagerId = '';
+let pgSql: postgres.Sql;
+
+beforeAll(async () => {
+  pg = await startPostgres();
+
+  server = Bun.spawn(['bun', 'run', SERVER_ENTRY], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, DATABASE_URL: pg.url, PORT: String(PORT) },
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+
+  await waitForServer(BASE);
+
+  // Register a sales_rep user (default role)
+  const salesRepUsername = `sales_rep_ship_test_${Date.now()}`;
+  const salesRes = await fetch(`${BASE}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: salesRepUsername, password: 'testpass123' }),
+  });
+  expect(salesRes.status).toBe(201);
+  const salesSetCookie = salesRes.headers.get('set-cookie') ?? '';
+  salesRepCookie = salesSetCookie.split(';')[0];
+
+  // Insert an inventory_manager user directly into the database
+  pgSql = postgres(pg.url, { max: 1 });
+  const invMgrUsername = `inv_mgr_ship_test_${Date.now()}`;
+  inventoryManagerId = crypto.randomUUID();
+  const invMgrHash = await Bun.password.hash('testpass123');
+  await pgSql`
+    INSERT INTO entities (id, type, properties, tenant_id)
+    VALUES (
+      ${inventoryManagerId},
+      'user',
+      ${pgSql.json({ username: invMgrUsername, password_hash: invMgrHash, role: 'inventory_manager', display_name: 'Test Inventory Manager' })},
+      null
+    )
+  `;
+
+  // Log in as the inventory_manager
+  const invMgrRes = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: invMgrUsername, password: 'testpass123' }),
+  });
+  expect(invMgrRes.status).toBe(200);
+  const invMgrSetCookie = invMgrRes.headers.get('set-cookie') ?? '';
+  inventoryManagerCookie = invMgrSetCookie.split(';')[0];
+}, 60_000);
+
+afterAll(async () => {
+  server?.kill();
+  await pgSql?.end({ timeout: 5 });
+  await pg?.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: create a standard test product with known inventory
+// ---------------------------------------------------------------------------
+
+async function createTestProduct(qtyOnHand = 100) {
+  const res = await fetch(`${BASE}/api/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: inventoryManagerCookie },
+    body: JSON.stringify({
+      name: '4x4 Welded Wire Mesh 10ga',
+      sku: `WM-SHIP-TEST-${Date.now()}`,
+      material: 'Galvanized Steel',
+      width_inches: 48,
+      length_inches: 120,
+      weight_per_sqft: 0.58,
+      cost_per_each: 32.0,
+      cost_per_linft: null,
+      cost_per_sqft: null,
+      primary_cost_basis: 'each',
+      margin_target: 25,
+      margin_floor: 15,
+      qty_on_hand_eaches: qtyOnHand,
+    }),
+  });
+  expect(res.status).toBe(201);
+  return res.json();
+}
+
+async function createAndConfirmOrder(productId: string, quantity = 5) {
+  // Create order (as sales_rep)
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: salesRepCookie },
+    body: JSON.stringify({
+      customer: `Ship Test Customer ${Date.now()}`,
+      product_id: productId,
+      quantity,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const order = await createRes.json();
+
+  // Confirm the order (as sales_rep)
+  const confirmRes = await fetch(`${BASE}/api/orders/${order.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: salesRepCookie },
+    body: JSON.stringify({ status: 'confirmed' }),
+  });
+  expect(confirmRes.status).toBe(200);
+  return confirmRes.json();
+}
+
+// ---------------------------------------------------------------------------
+// confirmed → shipped succeeds for inventory_manager
+// ---------------------------------------------------------------------------
+
+test('confirmed → shipped succeeds for inventory_manager', async () => {
+  const product = await createTestProduct(100);
+  const confirmedOrder = await createAndConfirmOrder(product.id, 5);
+  expect(confirmedOrder.properties.status).toBe('confirmed');
+
+  const shipRes = await fetch(`${BASE}/api/orders/${confirmedOrder.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: inventoryManagerCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+  expect(shipRes.status).toBe(200);
+  const shipped = await shipRes.json();
+  expect(shipped.properties.status).toBe('shipped');
+  expect(shipped.properties.shipped_by).toBe(inventoryManagerId);
+  expect(shipped.properties.shipped_at).toBeTruthy();
+});
+
+// ---------------------------------------------------------------------------
+// Shipment inventory_txn created with negative qty
+// ---------------------------------------------------------------------------
+
+test('shipment inventory_txn is created with negative qty_eaches', async () => {
+  const product = await createTestProduct(100);
+  const confirmedOrder = await createAndConfirmOrder(product.id, 7);
+
+  await fetch(`${BASE}/api/orders/${confirmedOrder.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: inventoryManagerCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+
+  // Verify inventory_txn was created in the database
+  const txnRows = await pgSql`
+    SELECT id, properties
+    FROM entities
+    WHERE type = 'inventory_txn'
+      AND properties->>'reference' = ${confirmedOrder.id}
+      AND properties->>'txn_type' = 'shipment'
+  `;
+
+  expect(txnRows.length).toBe(1);
+  const txn = txnRows[0].properties as Record<string, unknown>;
+  expect(txn.qty_eaches).toBe(-7);
+  expect(txn.txn_type).toBe('shipment');
+  expect(txn.product_id).toBe(product.id);
+  expect(txn.reference).toBe(confirmedOrder.id);
+});
+
+// ---------------------------------------------------------------------------
+// Product qty_on_hand decremented after shipment
+// ---------------------------------------------------------------------------
+
+test('product qty_on_hand_eaches decremented by order qty_eaches on shipment', async () => {
+  const initialQty = 50;
+  const orderQty = 8;
+  const product = await createTestProduct(initialQty);
+  const confirmedOrder = await createAndConfirmOrder(product.id, orderQty);
+
+  await fetch(`${BASE}/api/orders/${confirmedOrder.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: inventoryManagerCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+
+  // Fetch updated product
+  const productRows = await pgSql`
+    SELECT properties
+    FROM entities
+    WHERE id = ${product.id} AND type = 'product'
+  `;
+
+  expect(productRows.length).toBe(1);
+  const updatedProps = productRows[0].properties as Record<string, unknown>;
+  expect(updatedProps.qty_on_hand_eaches).toBe(initialQty - orderQty);
+});
+
+// ---------------------------------------------------------------------------
+// sales_rep gets 403 for shipped transition
+// ---------------------------------------------------------------------------
+
+test('sales_rep gets 403 when attempting shipped transition', async () => {
+  const product = await createTestProduct(100);
+  const confirmedOrder = await createAndConfirmOrder(product.id, 3);
+
+  const shipRes = await fetch(`${BASE}/api/orders/${confirmedOrder.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: salesRepCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+
+  expect(shipRes.status).toBe(403);
+  const body = await shipRes.json();
+  expect(body.error).toBe('Forbidden');
+});
+
+// ---------------------------------------------------------------------------
+// draft → shipped returns invalid transition error
+// ---------------------------------------------------------------------------
+
+test('draft → shipped returns 400 invalid transition error', async () => {
+  const product = await createTestProduct(100);
+
+  const createRes = await fetch(`${BASE}/api/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: salesRepCookie },
+    body: JSON.stringify({
+      customer: `Draft Ship Fail ${Date.now()}`,
+      product_id: product.id,
+      quantity: 3,
+      unit_of_measure: 'each',
+      sell_price_per_unit: 45.0,
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  const draftOrder = await createRes.json();
+  expect(draftOrder.properties.status).toBe('draft');
+
+  const shipRes = await fetch(`${BASE}/api/orders/${draftOrder.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Cookie: inventoryManagerCookie },
+    body: JSON.stringify({ status: 'shipped' }),
+  });
+
+  expect(shipRes.status).toBe(400);
+  const body = await shipRes.json();
+  expect(body.error).toContain('Invalid status transition');
+});
+
+// ---------------------------------------------------------------------------
+
+/** Poll the server until it responds or we time out. */
+async function waitForServer(base: string): Promise<void> {
+  const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${base}/api/auth/me`);
+      return;
+    } catch {
+      await Bun.sleep(300);
+    }
+  }
+  throw new Error(`Server at ${base} did not become ready within ${SERVER_READY_TIMEOUT_MS}ms`);
+}

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -37,7 +37,8 @@ CREATE INDEX IF NOT EXISTS idx_relations_type ON relations(type);
 
 -- Seed required entity types
 INSERT INTO entity_types (type, schema) VALUES
-  ('user',    '{}'),
-  ('product', '{}'),
-  ('order',   '{}')
+  ('user',          '{}'),
+  ('product',       '{}'),
+  ('order',         '{}'),
+  ('inventory_txn', '{}')
 ON CONFLICT (type) DO NOTHING;


### PR DESCRIPTION
Closes #83

## Summary

Implements the shipped transition on `PATCH /api/orders/:id`:

- Require `inventory_manager` or `admin` role for the `confirmed → shipped` transition
- On ship, create a `shipment` inventory_txn with `qty_eaches: -order.qty_eaches`
- Decrement `product.qty_on_hand_eaches` by `order.qty_eaches`
- Add `inventory_txn` entity type to `schema.sql`
- Integration tests covering all acceptance criteria

## Test plan

- confirmed → shipped succeeds for inventory_manager
- Shipment inventory_txn created with negative qty
- Product qty_on_hand decremented
- sales_rep gets 403 for shipped transition
- draft → shipped returns 400 invalid transition error