### PR TITLE
chore: symlink .claude/commands to .agents/commands

### DIFF
--- a/.claude/commands
+++ b/.claude/commands
@@ -1,0 +1,1 @@
+/home/lucas/calypso-cpq/.agents/commands


### PR DESCRIPTION
## Summary

- Creates `.claude/commands` as a symlink to `.agents/commands` so Claude Code slash commands are served directly from the agents submodule

## Test plan

- [x] Verify `.claude/commands` resolves to `.agents/commands` contents
- [x] Confirm slash commands (e.g. `/develop`, `/replan`) are available in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)